### PR TITLE
Fix REGRESS so all tests run on Mac OS X.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2018-08-29         Arnold D. Robbins     <arnold@skeeve.com>
+
+	* REGRESS: Check for existence of a.out. If not there, run
+	make.  Enable core dumps for T.arnold system status test
+	to work on MacOS X.
+
 2018-08-22         Arnold D. Robbins     <arnold@skeeve.com>
 
 	* awktest.tar (testdir/T.expr): Fix test for unary plus.

--- a/REGRESS
+++ b/REGRESS
@@ -1,5 +1,15 @@
 #! /bin/sh
 
+case `uname` in
+CYGWIN)	EXE=a.exe ;;
+*)	EXE=a.out ;;
+esac
+
+if [ ! -f $EXE ]
+then
+	make || exit 1
+fi
+
 if [ -d testdir ]
 then
 	true	# do nothing
@@ -16,5 +26,10 @@ cd testdir
 pwd
 PATH=.:$PATH
 export PATH
+if (ulimit -c unlimited > /dev/null 2>&1)
+then
+	# Workaround broken default on MacOS X
+	ulimit -c unlimited
+fi
 
 REGRESS


### PR DESCRIPTION
The problem with Mac OS X is that by default the ulimit setting for core dumps is set to zero.  This fixes REGRESS to make it be unlmited.  Along the way, if a.out is not there it will run make and exit early if make fails.

I have tried to use very portable constructs in the shell script.