### PR TITLE
Check for format character precision argument before using it

### DIFF
--- a/bugs-fixed/README
+++ b/bugs-fixed/README
@@ -23,3 +23,6 @@ and also if CONVFMT changed.
 
 7. unary-plus: Unary plus on a string constant returned the string.
 Instead, it should convert the value to numeric and give that value.
+
+8. missing-precision: When using the format string "%*s", the precision
+argument was used without checking if it was present first.

--- a/bugs-fixed/missing-precision.awk
+++ b/bugs-fixed/missing-precision.awk
@@ -1,0 +1,1 @@
+BEGIN { printf("%*s"); }

--- a/bugs-fixed/missing-precision.ok
+++ b/bugs-fixed/missing-precision.ok
@@ -1,0 +1,2 @@
+./a.out: not enough args in printf(%*s)
+ source line number 1

--- a/run.c
+++ b/run.c
@@ -863,6 +863,9 @@ int format(char **pbuf, int *pbufsize, const char *s, Node *a)	/* printf-like co
 				FATAL("'$' not permitted in awk formats");
 			}
 			if (*s == '*') {
+				if (a == NULL) {
+					FATAL("not enough args in printf(%s)", os);
+				}
 				x = execute(a);
 				a = a->nnext;
 				sprintf(t-1, "%d", fmtwd=(int) getfval(x));


### PR DESCRIPTION
This adds a check for when the precision argument is missing (e.g., `printf("%*s")`). I've added an example program to `bugs-fixed`.