### PR TITLE
Improve error reporting messages

### DIFF
--- a/lex.c
+++ b/lex.c
@@ -198,6 +198,7 @@ int yylex(void)
 		yylval.i = c;
 		switch (c) {
 		case '\n':	/* {EOL} */
+			lineno++;
 			RET(NL);
 		case '\r':	/* assume \n is coming */
 		case ' ':	/* {WS}+ */
@@ -213,6 +214,7 @@ int yylex(void)
 		case '\\':
 			if (peek() == '\n') {
 				input();
+				lineno++;
 			} else if (peek() == '\r') {
 				input(); input();	/* \n */
 				lineno++;
@@ -370,10 +372,11 @@ int string(void)
 		case '\n':
 		case '\r':
 		case 0:
+			*bp = '\0';
 			SYNTAX( "non-terminated string %.10s...", buf );
-			lineno++;
 			if (c == 0)	/* hopeless */
 				FATAL( "giving up" );
+			lineno++;
 			break;
 		case '\\':
 			c = input();
@@ -515,6 +518,7 @@ int regexpr(void)
 		if (!adjbuf(&buf, &bufsz, bp-buf+3, 500, &bp, "regexpr"))
 			FATAL("out of space for reg expr %.10s...", buf);
 		if (c == '\n') {
+			*bp = '\0';
 			SYNTAX( "newline in regular expression %.10s...", buf ); 
 			unput('\n');
 			break;
@@ -553,19 +557,19 @@ int input(void)	/* get next lexical input character */
 			lexprog++;
 	} else				/* awk -f ... */
 		c = pgetc();
-	if (c == '\n')
-		lineno++;
-	else if (c == EOF)
+	if (c == EOF)
 		c = 0;
 	if (ep >= ebuf + sizeof ebuf)
 		ep = ebuf;
-	return *ep++ = c;
+	*ep = c;
+	if (c != 0) {
+		ep++;
+	}
+	return (c);
 }
 
 void unput(int c)	/* put lexical character back on input */
 {
-	if (c == '\n')
-		lineno--;
 	if (yysptr >= yysbuf + sizeof(yysbuf))
 		FATAL("pushed back too much: %.20s...", yysbuf);
 	*yysptr++ = c;


### PR DESCRIPTION
This fixes some issues with the syntax error messages that I noticed while looking at the tests `gawk` has for syntax errors. For example:

```
cpm@enlil ~/src/awk : error-reporting % ./old-nawk '/'
./old-nawk: non-terminated regular expression ... at source line 1
 context is
         >>>  <<< 
cpm@enlil ~/src/awk : error-reporting (2) % ./old-nawk '/['
./old-nawk: non-terminated regular expression [... at source line 1
 context is
         >>>  <<< 
./old-nawk: nonterminated character class [
 source line number 1
cpm@enlil ~/src/awk : error-reporting (2) % ./old-nawk '/\'
./old-nawk: non-terminated regular expression \... at source line 1
 context is
         >>>  <<< 
cpm@enlil ~/src/awk : error-reporting (2) % ./old-nawk $'/[\n'
./old-nawk: newline in regular expression []4E... at source line 2
 context is
        /[ >>> 
 <<< 
./old-nawk: nonterminated character class [
 source line number 1
cpm@enlil ~/src/awk : error-reporting (2) % ./old-nawk 'BEGIN { a='
./old-nawk: syntax error at source line 1
 context is
         >>>  <<< 
./old-nawk: illegal statement at source line 1
        missing }
cpm@enlil ~/src/awk : error-reporting (2) % ./old-nawk 'BEGIN { a="'
./old-nawk: non-terminated string �:�... at source line 1
 context is
         >>>  <<< 
./old-nawk: giving up
 source line number 2
```

With these changes, these are now:

```
cpm@enlil ~/src/awk : error-reporting % ./a.out '/'
./a.out: non-terminated regular expression ... at source line 1
 context is
         >>> / <<< 
cpm@enlil ~/src/awk : error-reporting (2) % ./a.out '/['
./a.out: non-terminated regular expression [... at source line 1
 context is
         >>> /[ <<< 
./a.out: nonterminated character class [
 source line number 1
cpm@enlil ~/src/awk : error-reporting (2) % ./a.out '/\'
./a.out: non-terminated regular expression \... at source line 1
 context is
         >>> /\ <<< 
cpm@enlil ~/src/awk : error-reporting (2) % ./a.out $'/[\n'
./a.out: newline in regular expression [... at source line 1
 context is
        /[ >>> 
 <<< 
./a.out: nonterminated character class [
 source line number 1
cpm@enlil ~/src/awk : error-reporting (2) % ./a.out 'BEGIN { a='
./a.out: syntax error at source line 1
 context is
        BEGIN { >>>  a <<< 
./a.out: illegal statement at source line 1
        missing }
cpm@enlil ~/src/awk : error-reporting (2) % ./a.out 'BEGIN { a="'
./a.out: non-terminated string ... at source line 1
 context is
        BEGIN { >>>  a=" <<< 
./a.out: giving up
 source line number 1
```