### PR TITLE
Flags that begin with "--" should not be treated as end of args

### DIFF
--- a/main.c
+++ b/main.c
@@ -88,7 +88,7 @@ int main(int argc, char *argv[])
 			exit(0);
 			break;
 		}
-		if (strncmp(argv[1], "--", 2) == 0) {	/* explicit end of args */
+		if (strcmp(argv[1], "--") == 0) {	/* explicit end of args */
 			argc--;
 			argv++;
 			break;


### PR DESCRIPTION
The check for the explcit end of arguments flag (`--`) uses `strncmp` with a length of 2, instead of 3 (`sizeof ("--")`), which means that it treats all flags that begin with two dashes as the end. This can create some confusing messages:

```
cpm@enlil ~/src/awk : end-of-args % ./old-nawk --help
./old-nawk: no program given

cpm@enlil ~/src/awk : end-of-args (2) % ./old-nawk --file bugs-fixed/a-format.awk 
./old-nawk: syntax error at source line 1
 context is
         >>> bugs-fixed/a-format. <<< awk
./old-nawk: bailing out at source line 1
```

I've switched this back to using `strcmp`, which is what it used before ~2007, when the `-version` and `--version` flags were added. Using the above flags now produces the "unknown option" message:

```
cpmcpm@enlil ~/src/awk : end-of-args % ./a.out --help
./a.out: unknown option --help ignored

./a.out: no program given

cpm@enlil ~/src/awk : end-of-args (2) % ./a.out --file bugs-fixed/a-format.awk 
./a.out: unknown option --file ignored

./a.out: syntax error at source line 1
 context is
         >>> bugs-fixed/a-format. <<< awk
./a.out: bailing out at source line 1
cpm@enlil ~/src/awk : end-of-args (2) % ./a.out -version
awk version 20180827
cpm@enlil ~/src/awk : end-of-args % ./a.out --version
awk version 20180827@enlil ~/src/awk : end-of-args % ./a.out --help
./a.out: unknown option --help ignored

./a.out: no program given

cpm@enlil ~/src/awk : end-of-args (2) % ./a.out --file bugs-fixed/a-format.awk 
./a.out: unknown option --file ignored

./a.out: syntax error at source line 1
 context is
         >>> bugs-fixed/a-format. <<< awk
./a.out: bailing out at source line 1
cpm@enlil ~/src/awk : end-of-args (2) % ./a.out -version
awk version 20180827
cpm@enlil ~/src/awk : end-of-args % ./a.out --version
awk version 20180827
```

(h/t to @rmustacc for finding this)