### PR TITLE
Fix regular expressions containing [[:cntrl:]]

### DIFF
--- a/b.c
+++ b/b.c
@@ -823,7 +823,15 @@ int relex(void)		/* lexical analyzer for reparse */
 				if (cc->cc_name != NULL && prestr[1 + cc->cc_namelen] == ':' &&
 				    prestr[2 + cc->cc_namelen] == ']') {
 					prestr += cc->cc_namelen + 3;
-					for (i = 0; i < NCHARS; i++) {
+					/*
+					 * BUG: We begin at 1, instead of 0, since we
+					 * would otherwise prematurely terminate the
+					 * string for classes like [[:cntrl:]]. This
+					 * means that we can't match the NUL character,
+					 * not without first adapting the entire
+					 * program to track each string's length.
+					 */
+					for (i = 1; i < NCHARS; i++) {
 						if (!adjbuf((char **) &buf, &bufsz, bp-buf+1, 100, (char **) &bp, "relex2"))
 						    FATAL("out of space for reg expr %.10s...", lastre);
 						if (cc->cc_func(i)) {


### PR DESCRIPTION
This fixes using the `[[:cntrl:]]` character class. Because the string for the class currently gets terminated early, it matches anything. For example:

```
% gawk 'BEGIN { print ("^G" ~ /[[:cntrl:]]/), ("f" ~ /[[:cntrl:]]/); }'
1 0
% mawk 'BEGIN { print ("^G" ~ /[[:cntrl:]]/), ("f" ~ /[[:cntrl:]]/); }'
1 0
% ./old-nawk 'BEGIN { print ("^G" ~ /[[:cntrl:]]/), ("f" ~ /[[:cntrl:]]/); }' 
1 1
% ./a.out 'BEGIN { print ("^G" ~ /[[:cntrl:]]/), ("f" ~ /[[:cntrl:]]/); }' 
1 0
```

`a.out` is with the fix, `old-nawk` is before the fix.