### PR TITLE
Fix initial "fields" buffer size

### DIFF
--- a/lib.c
+++ b/lib.c
@@ -59,7 +59,7 @@ void recinit(unsigned int n)
 {
 	if ( (record = (char *) malloc(n)) == NULL
 	  || (fields = (char *) malloc(n+1)) == NULL
-	  || (fldtab = (Cell **) malloc((nfields+1) * sizeof(Cell *))) == NULL
+	  || (fldtab = (Cell **) malloc((nfields+2) * sizeof(Cell *))) == NULL
 	  || (fldtab[0] = (Cell *) malloc(sizeof(Cell))) == NULL )
 		FATAL("out of space for $0 and fields");
 	*fldtab[0] = dollar0;


### PR DESCRIPTION
This fixes an issue with the initial buffer size for `fields`, so that it contains enough space for the two possible terminating `\0`'s in [fldbld()](https://github.com/onetrueawk/awk/blob/e8c280034fad30d5234590ac3c62ebd0fe3d25dd/lib.c#L305-L307) (which already accounts for the needed space [here](https://github.com/onetrueawk/awk/blob/e8c280034fad30d5234590ac3c62ebd0fe3d25dd/lib.c#L280); the [refldbld()](https://github.com/onetrueawk/awk/blob/e8c280034fad30d5234590ac3c62ebd0fe3d25dd/lib.c#L442) allocation seems to be unreachable due to the `fldbld()` check).  The easiest way I've found to reproduce this is on illumos using the memory allocator's [debugging features](http://illumos.org/man/3malloc/umem_debug) to detect the overflow when the buffer gets freed:

```
% LD_PRELOAD=/usr/lib/libumem.so UMEM_DEBUG=default ./old-nawk -v RECSIZE=8192 'BEGIN { for (c = 0; c < 3; c++) { a = (RECSIZE % 2 > 0 ? "5" : "55"); while (length(a) < RECSIZE + c) { a = a " 5"; } $0 = a; print $3; } }'
5
zsh: IOT instruction (core dumped)  LD_PRELOAD=/usr/lib/libumem.so UMEM_DEBUG=default ./old-nawk -v RECSIZE=8192
% LD_PRELOAD=/usr/lib/libumem.so UMEM_DEBUG=default ./a.out -v RECSIZE=8192 'BEGIN { for (c = 0; c < 3; c++) { a = (RECSIZE % 2 > 0 ? "5" : "55"); while (length(a) < RECSIZE + c) { a = a " 5"; } $0 = a; print $3; } }'
5
5
5
```

`a.out` is with the fix, `old-nawk` is before the fix.