### PR TITLE
Fixed DIVEQ grammar bug

### DIFF
--- a/awkgram.y
+++ b/awkgram.y
@@ -349,8 +349,7 @@ subop:
 	;
 
 term:
- 	  term '/' ASGNOP term		{ $$ = op2(DIVEQ, $1, $4); }
- 	| term '+' term			{ $$ = op2(ADD, $1, $3); }
+ 	  term '+' term			{ $$ = op2(ADD, $1, $3); }
 	| term '-' term			{ $$ = op2(MINUS, $1, $3); }
 	| term '*' term			{ $$ = op2(MULT, $1, $3); }
 	| term '/' term			{ $$ = op2(DIVIDE, $1, $3); }

--- a/lex.c
+++ b/lex.c
@@ -287,7 +287,10 @@ int yylex(void)
 			} else
 				RET('*');
 		case '/':
-			RET('/');
+			if (peek() == '=') {
+				input(); yylval.i = DIVEQ; RET(ASGNOP);
+			} else
+        RET('/');
 		case '%':
 			if (peek() == '=') {
 				input(); yylval.i = MODEQ; RET(ASGNOP);


### PR DESCRIPTION
Uses the same parsing as +=, -=, etc. The previous grammar allowed nonsensical expressions like 'a +b /= c+d'.