### PR TITLE
maketab: support build systems with read-only source.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+a.out
+maketab
+proctab.c
+ytab.c
+ytab.h
+*.o

--- a/makefile
+++ b/makefile
@@ -67,7 +67,7 @@ y%.c y%.h:	awk.h proto.h awkgram.y
 ytab.h:	ytab.c
 
 proctab.c:	maketab
-	./maketab >proctab.c
+	./maketab ytab.h >proctab.c
 
 maketab:	ytab.h maketab.c
 	$(CC) $(CFLAGS) maketab.c -o maketab

--- a/maketab.c
+++ b/maketab.c
@@ -125,8 +125,12 @@ int main(int argc, char *argv[])
 	for (i = SIZE; --i >= 0; )
 		names[i] = "";
 
-	if ((fp = fopen("ytab.h", "r")) == NULL) {
-		fprintf(stderr, "maketab can't open ytab.h!\n");
+	if (argc != 2) {
+		fprintf(stderr, "usage: maketab YTAB_H\n");
+		exit(1);
+	}
+	if ((fp = fopen(argv[1], "r")) == NULL) {
+		fprintf(stderr, "maketab can't open %s!\n", argv[1]);
 		exit(1);
 	}
 	printf("static char *printname[%d] = {\n", SIZE);


### PR DESCRIPTION
If your generated files are considered outputs that live elsewhere, you
need a way to tell maketab where ytab.h actually is.

Specifically, I'm trying to avoid checking in generated files in
Android's AOSP tree's copy of one-true-awk.