### PR TITLE
Update field-splitting behaviour to match POSIX definition

### DIFF
--- a/proto.h
+++ b/proto.h
@@ -116,6 +116,7 @@ extern	void	recinit(unsigned int);
 extern	void	initgetrec(void);
 extern	void	makefields(int, int);
 extern	void	growfldtab(int n);
+extern	void	savefs(void);
 extern	int	getrec(char **, int *, int);
 extern	void	nextfile(void);
 extern	int	readrec(char **buf, int *bufsize, FILE *inf);

--- a/tran.c
+++ b/tran.c
@@ -318,6 +318,7 @@ Awkfloat setfval(Cell *vp, Awkfloat f)	/* set float val of a Cell */
 	} else if (isrec(vp)) {
 		donefld = 0;	/* mark $1... invalid */
 		donerec = 1;
+		savefs();
 	} else if (vp == ofsloc) {
 		if (donerec == 0)
 			recbld();
@@ -362,6 +363,7 @@ char *setsval(Cell *vp, const char *s)	/* set string val of a Cell */
 	} else if (isrec(vp)) {
 		donefld = 0;	/* mark $1... invalid */
 		donerec = 1;
+		savefs();
 	} else if (vp == ofsloc) {
 		if (donerec == 0)
 			recbld();


### PR DESCRIPTION
The POSIX specification for `awk(1)` [specifies](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/awk.html):

> Before the first reference to a field in the record is evaluated, the record shall be split into fields, according to the rules in Regular Expressions, using the value of FS that was current at the time the record was read.

Since `nawk` splits the fields lazily at the point where they are first referenced, [these lines](https://github.com/onetrueawk/awk/blob/20180827/lib.c#L193-L196) were added in 1996 to save the value:

```
Jun 28, 1996:
        changed field-splitting to conform to posix definition: fields are
        split using the value of FS at the time of input; it used to be
        the value when the field or NF was first referred to, a much less
        predictable definition.  thanks to arnold robbins for encouragement
        to do the right thing.

Jun 29, 1996:
        fixed awful bug in new field splitting; didn't get all the places
        where input was done.
```

Which meant that programs like this then worked:

```
% getent passwd cody root
cody:x:1000:1::/home/cody:/opt/local/bin/zsh
root:x:0:0:Super-User:/root:/usr/bin/bash
% printf 'foo cody\nbar root' | nawk-20071023 '{ FS=":"; "getent passwd " $2 | getline; print $1 " shell is " $7; }'
cody shell is /opt/local/bin/zsh
root shell is /usr/bin/bash
% printf 'foo cody\nbar root' | /usr/xpg4/bin/awk '{ FS=":"; "getent passwd " $2 | getline; print $1 " shell is " $7; }' 
cody shell is /opt/local/bin/zsh
root shell is /usr/bin/bash
% printf 'foo cody\nbar root' | gawk '{ FS=":"; "getent passwd " $2 | getline; print $1 " shell is " $7; }'             
cody shell is /opt/local/bin/zsh
root shell is /usr/bin/bash
% printf 'foo cody\nbar root' | mawk '{ FS=":"; ("getent passwd " $2) | getline; print $1 " shell is " $7; }'
cody shell is /opt/local/bin/zsh
root shell is /usr/bin/bash
```

(The `mawk` program is slightly altered since its associativity rules seem to differ.)

And on a Linux system with BusyBox `awk`:

```
cpm@enlil ~ % getent passwd cpm root
cpm:x:1000:1000:Cody Mello,,,:/home/cpm:/bin/zsh
root:x:0:0:root:/root:/bin/zsh
cpm@enlil ~ % /usr/bin/awk --help 2>&1 | head -n1                                                                                 
BusyBox v1.28.4 (2018-07-17 15:21:40 UTC) multi-call binary.
cpm@enlil ~ % printf 'foo cpm\nbar root' | /usr/bin/awk '{ FS=":"; "getent passwd " $2 | getline; print $1 " shell is " $7; }'
cpm shell is /bin/zsh
root shell is /bin/zsh
```

Whereas before `$2` would have been the empty string, since the input was lazily split on colons:

```
% printf 'foo cody\nbar root' | nawk-19940824 '{ FS=":"; "getent passwd " $2 | getline; print $1 " shell is " $7; }'
root shell is /usr/bin/bash
daemon shell is
```

However, this breaks the case where `$0` is assigned to directly:

```
% nawk-20071023 'BEGIN { FS=":"; $0="a:b:c:d"; print $2 }'

% nawk-19940824 'BEGIN { FS=":"; $0="a:b:c:d"; print $2 }'         
b
```

So in 2009 [these lines were added](https://github.com/onetrueawk/awk/blob/20180827/lib.c#L286):

```
Nov 26, 2009: 
        fixed a long-standing issue with when FS takes effect.  a
        change to FS is now noticed immediately for subsequent splits.
```

Which fixes assigning to `$0`, but undoes the original attempt to match the POSIX behaviour (and that of other implementations):

```
% nawk-20091126 'BEGIN { FS=":"; $0="a:b:c:d"; print $2 }' 
b
% printf 'foo cody\nbar root' | nawk-20091126 '{ FS=":"; "getent passwd " $2 | getline; print $1 " shell is " $7; }' 
root shell is /usr/bin/bash
daemon shell is 
```

Additionally, the way that all of these have been done at each point means that using `getline` with a variable will change how the fields are split, when it's not supposed to:

```
% printf 'foo cody\nbar root' | nawk-19940824 '{ FS=":"; "getent passwd cody" | getline v; print "$2 is " $2; FS=" "; }'             
$2 is 
$2 is 
% printf 'foo cody\nbar root' | nawk-20071023 '{ FS=":"; "getent passwd cody" | getline v; print "$2 is " $2; FS=" "; }' 
$2 is 
$2 is 
% printf 'foo cody\nbar root' | nawk-20091126 '{ FS=":"; "getent passwd cody" | getline v; print "$2 is " $2; FS=" "; }' 
$2 is 
$2 is 
% printf 'foo cody\nbar root' | /usr/xpg4/bin/awk '{ FS=":"; "getent passwd cody" | getline v; print "$2 is " $2; FS=" "; }'
$2 is cody
$2 is root
% printf 'foo cody\nbar root' | gawk '{ FS=":"; "getent passwd cody" | getline v; print "$2 is " $2; FS=" "; }'             
$2 is cody
$2 is root
% printf 'foo cody\nbar root' | mawk '{ FS=":"; "getent passwd cody" | getline v; print "$2 is " $2; FS=" "; }'
$2 is cody
$2 is root
```

And on a Linux system with the BusyBox `awk`:

```
cpm@enlil ~ % /usr/bin/awk --help 2>&1 | head -n1
BusyBox v1.28.4 (2018-07-17 15:21:40 UTC) multi-call binary.
cpm@enlil ~ % printf 'foo cody\nbar root' | /usr/bin/awk '{ FS=":"; "getent passwd cpm" | getline v; print "$2 is " $2; FS=" "; }' 
$2 is cody
$2 is root
```

This PR moves where `FS` gets saved to the places where `$0` is updated. Here's a modified version of `T.split` that I've been using to test these changes:

```bash
#!/bin/bash

if [[ -z "$AWK" ]]; then
    printf '$AWK must be set\n' >&2
    exit 1
fi

WORKDIR=$(mktemp -d /tmp/nawktest.XXXXXX)

TEMP0=$WORKDIR/test.temp.0
TEMP1=$WORKDIR/test.temp.1
TEMP2=$WORKDIR/test.temp.2

RESULT=0

fail() {
	echo "$1" >&2
	RESULT=1
}

echo T.split: misc tests of field splitting and split command

$AWK 'BEGIN {
	# Assign string to $0, then change FS.
	FS = ":";
	$0="a:bc:def";
	FS = "-";
	print FS, $1, NF;

	# Assign number to $0, then change FS.
	FS = "2";
	$0=1212121;
	FS="3";
	print FS, $1, NF;
}' > $TEMP1
echo '- a 3
3 1 4' > $TEMP2
diff $TEMP1 $TEMP2 || fail 'BAD: T.split 0.1'

$AWK 'BEGIN {
	# FS changes after getline.
	FS = ":";
	"echo a:bc:def" | getline;
	FS = "-";
	print FS, $1, NF;
}' > $TEMP1
echo '- a 3' > $TEMP2
diff $TEMP1 $TEMP2 || fail 'BAD: T.split 0.2'

echo '
a
a:b
c:d:e
e:f:g:h' > $TEMP0
$AWK 'BEGIN {
	FS = ":"
	while (getline <"'$TEMP0'" > 0) 
		print NF
}' > $TEMP1
echo '0
1
2
3
4' > $TEMP2
diff $TEMP1 $TEMP2 || fail 'BAD: T.split 0.3'

# getline var shouldn't impact fields.

echo 'f b a' > $TEMP0
$AWK '{
	FS = ":";
	getline a < "/etc/passwd";
	print $1;
}' $TEMP0 > $TEMP1
echo 'f' > $TEMP2
diff $TEMP1 $TEMP2 || fail 'BAD: T.split 0.4'

echo 'a b c d
foo
e f g h i
bar' > $TEMP0
$AWK '{
	FS=":";
	getline v;
	print $2, NF;
	FS=" ";
}' $TEMP0 > $TEMP1
echo 'b 4
f 5' > $TEMP2
diff $TEMP1 $TEMP2 || fail 'BAD: T.split 0.5'

echo 'a.b.c=d.e.f
g.h.i=j.k.l
m.n.o=p.q.r' > $TEMP0
echo 'b
h
n' > $TEMP1
$AWK 'BEGIN { FS="=" } { FS="."; $0=$1; print $2; FS="="; }' $TEMP0 > $TEMP2
diff $TEMP1 $TEMP2 || fail 'BAD: T.split (record assignment 1)'

echo 'a.b.c=d.e.f
g.h.i=j.k.l
m.n.o=p.q.r' > $TEMP0
echo 'd.e.f
b
j.k.l
h
p.q.r
n' > $TEMP1
$AWK 'BEGIN { FS="=" } { print $2; FS="."; $0=$1; print $2; FS="="; }' $TEMP0 > $TEMP2
diff $TEMP1 $TEMP2 || fail 'BAD: T.split (record assignment 2)'

echo 'abc
de
f

     ' > $TEMP0
who | sed 10q  >> $TEMP0
sed 10q /etc/passwd >> $TEMP0

$AWK '
{	n = split($0, x, "")
	m = length($0)
	if (m != n) print "error 1", NR
	s = ""
	for (i = 1; i <= m; i++)
		s = s x[i]
	if (s != $0) print "error 2", NR
	print s
}' $TEMP0 > $TEMP1

diff $TEMP0 $TEMP1 || fail 'BAD: T.split 1'

# assumes same test.temp.0!  bad design


$AWK '
{	n = split($0, x, //)
	m = length($0)
	if (m != n) print "error 1", NR
	s = ""
	for (i = 1; i <= m; i++)
		s = s x[i]
	if (s != $0) print "error 2", NR
	print s
}' $TEMP0 > $TEMP1

diff $TEMP0 $TEMP1 || fail 'BAD: T.split //'

$AWK '
BEGIN { FS = "" }
{	n = split($0, x)	# will be split with FS
	m = length($0)
	if (m != n) print "error 1", NR
	s = ""
	for (i = 1; i <= m; i++)
		s = s x[i]
	if (s != $0) print "error 2", NR
	print s
}' $TEMP0 > $TEMP2

diff $TEMP0 $TEMP2 || fail 'BAD: T.split 2'

# assumes same test.temp.0!

$AWK '
BEGIN { FS = "" }
{	n = NF
	m = length($0)
	if (m != n) print "error 1", NR
	s = ""
	for (i = 1; i <= m; i++)
		s = s $i
	if (s != $0) print "error 2", NR
	print s
}' $TEMP0 > $TEMP2

diff $TEMP0 $TEMP2 || fail 'BAD: T.split 3'


$AWK '
{ n = split( $0, temp, /^@@@ +/ )
  print n
}' > $TEMP1 <<XXX
@@@ xxx
@@@ xxx
@@@ xxx
XXX
echo '2
2
2' > $TEMP2
diff $TEMP1 $TEMP2 || fail 'BAD: T.split 4'

rm -f $WORKDIR/test.temp*

echo '
a
bc
def' > $TEMP0
$AWK '
{ print split($0, x, "")
}' $TEMP0 > $TEMP1
echo '0
1
2
3' > $TEMP2
diff $TEMP1 $TEMP2 || fail 'BAD: T.split null 3rd arg'

rm -f $WORKDIR/test.temp*
$AWK 'BEGIN {
  a[1]="a b"
  print split(a[1],a),a[1],a[2]
}' > $TEMP1

echo '2 a b' > $TEMP2
diff $TEMP1 $TEMP2 || fail 'BAD: T.split(a[1],a)'

$AWK 'BEGIN {
  a = "cat\n\n\ndog";
  split(a, b, "[\r\n]+");
  print b[1], b[2];
}' > $TEMP1
echo 'cat dog' > $TEMP2
diff $TEMP1 $TEMP2 || fail 'BAD: T.split(a, b, "[\r\n]+")'


exit $RESULT
```

Running this with several different AWK implementations:

```
cpm@enlil ~/src/awk : posix-fs % AWK=./a.out ./T.split 
T.split: misc tests of field splitting and split command
cpm@enlil ~/src/awk : posix-fs % AWK=gawk ./T.split
T.split: misc tests of field splitting and split command
cpm@enlil ~/src/awk : posix-fs % AWK=mawk ./T.split
T.split: misc tests of field splitting and split command
cpm@enlil ~/src/awk : posix-fs % AWK=/usr/bin/awk ./T.split
T.split: misc tests of field splitting and split command
```