### PR TITLE
Disallow deleting SYMTAB and its elements

### DIFF
--- a/FIXES
+++ b/FIXES
@@ -25,6 +25,11 @@ THIS SOFTWARE.
 This file lists all bug fixes, changes, etc., made since the AWK book
 was sent to the printers in August, 1987.
 
+June 17, 2019:
+	Disallow deleting SYMTAB and its elements, which creates
+	use-after-free bugs. Thanks to GitHub user Cody Mello (melloc)
+	for the fix. (Merged from PR #43.)
+
 June 5, 2019:
 	Allow unmatched right parenthesis in a regular expression to
 	be treated literally. Fixes Issue #40. Thanks to GitHub user

--- a/awk.h
+++ b/awk.h
@@ -105,6 +105,7 @@ extern Cell	*rsloc;		/* RS */
 extern Cell	*rstartloc;	/* RSTART */
 extern Cell	*rlengthloc;	/* RLENGTH */
 extern Cell	*subseploc;	/* SUBSEP */
+extern Cell	*symtabloc;	/* SYMTAB */
 
 /* Cell.tval values: */
 #define	NUM	01	/* number value is valid */

--- a/main.c
+++ b/main.c
@@ -22,7 +22,7 @@ ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 ****************************************************************/
 
-const char	*version = "version 20190605";
+const char	*version = "version 20190617";
 
 #define DEBUG
 #include <stdio.h>

--- a/run.c
+++ b/run.c
@@ -512,6 +512,9 @@ Cell *awkdelete(Node **a, int n)	/* a[0] is symtab, a[1] is list of subscripts *
 	int nsub;
 
 	x = execute(a[0]);	/* Cell* for symbol table */
+	if (x == symtabloc) {
+		FATAL("cannot delete SYMTAB or its elements");
+	}
 	if (!isarr(x))
 		return True;
 	if (a[1] == 0) {	/* delete the elements, not the table */


### PR DESCRIPTION
If you `delete SYMTAB`, it frees the table and everything in it. This can lead to reading from freed memory later on:

```
% printf "a b c\nd e f\n" | ./a.out '{ delete SYMTAB; print $2; }'
b
./a.out: illegal field $(), name "4"
 input record number 2, file
 source line number 1
% printf "a b c\nd e f\n" | LD_PRELOAD=/usr/lib/libumem.so UMEM_DEBUG=default ./a.out '{ delete SYMTAB; print $2; }'
zsh: done                              printf "a b c\nd e f\n" |
zsh: segmentation fault (core dumped)  LD_PRELOAD=/usr/lib/libumem.so UMEM_DEBUG=default ./a.out
```

I've added a guard to prevent deleting the table, or anything from it, and produce a `FATAL` error message instead:

```
% printf "a b c\nd e f\n" | ./a.out '{ delete SYMTAB; print $2; }'
./a.out: cannot delete SYMTAB or its elements
 input record number 1, file 
 source line number 1
% printf "a b c\nd e f\n" | ./a.out '{ delete SYMTAB["OFS"]; print $2; }'
./a.out: cannot delete SYMTAB or its elements
 input record number 1, file 
 source line number 1
```