### PR TITLE
Add support for "\a" and "\v" to regex and command line args

### DIFF
--- a/FIXES
+++ b/FIXES
@@ -25,6 +25,13 @@ THIS SOFTWARE.
 This file lists all bug fixes, changes, etc., made since the AWK book
 was sent to the printers in August, 1987.
 
+July 26, 2019:
+	Support POSIX-specified C-style escape sequences "\a" (alarm)
+	and "\v" (vertical tab) in command line arguments and regular
+	expressions, further to the support for them in strings added on
+	Apr 9, 1989. These now no longer match as literal "a" and "v"
+	characters (as they don't on other awk implementations).
+
 July 17, 2019:
 	Pull in a number of code cleanups and minor fixes from
 	Warner Losh's bsd-ota branch.  The only user visible change

--- a/b.c
+++ b/b.c
@@ -279,6 +279,10 @@ int quoted(uschar **pp)	/* pick up next thing after a \\ */
 		c = '\r';
 	else if (c == 'b')
 		c = '\b';
+	else if (c == 'v')
+		c = '\v';
+	else if (c == 'a')
+		c = '\a';
 	else if (c == '\\')
 		c = '\\';
 	else if (c == 'x') {	/* hexadecimal goo follows */

--- a/main.c
+++ b/main.c
@@ -22,7 +22,7 @@ ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 ****************************************************************/
 
-const char	*version = "version 20190717";
+const char	*version = "version 20190726";
 
 #define DEBUG
 #include <stdio.h>

--- a/tran.c
+++ b/tran.c
@@ -543,6 +543,8 @@ char *qstring(const char *is, int delim)	/* collect string up to next delim */
 			case 'b':	*bp++ = '\b'; break;
 			case 'f':	*bp++ = '\f'; break;
 			case 'r':	*bp++ = '\r'; break;
+			case 'v':	*bp++ = '\v'; break;
+			case 'a':	*bp++ = '\a'; break;
 			default:
 				if (!isdigit(c)) {
 					*bp++ = c;


### PR DESCRIPTION
Support POSIX-specified C-style escape sequences "\a" (alarm)
and "\v" (vertical tab) in command line arguments and regular
expressions, further to the support for them in strings added on
Apr 9, 1989. These now no longer match as literal "a" and "v"
characters (as they don't on gawk and mawk).

IOW, lex.c already supported these (lines 390-391 as of 4e343460);
the support needed to be added to b.c and tran.c.

Relevant POSIX reference:
http://pubs.opengroup.org/onlinepubs/9699919799/utilities/awk.html#tag_20_06_13_04