### PR TITLE
Fix out-of-bounds access in gototab array for caret character

### DIFF
--- a/awk.h
+++ b/awk.h
@@ -212,6 +212,7 @@ extern	int	pairstack[], paircnt;
 
 #define NCHARS	(256+3)		/* 256 handles 8-bit chars; 128 does 7-bit */
 				/* watch out in match(), etc. */
+#define	HAT	(NCHARS+2)	/* matches ^ in regular expr */
 #define NSTATES	32
 
 typedef struct rrow {
@@ -225,7 +226,7 @@ typedef struct rrow {
 } rrow;
 
 typedef struct fa {
-	uschar	gototab[NSTATES][NCHARS];
+	uschar	gototab[NSTATES][HAT + 1];
 	uschar	out[NSTATES];
 	uschar	*restr;
 	int	*posns[NSTATES];

--- a/b.c
+++ b/b.c
@@ -34,8 +34,6 @@ THIS SOFTWARE.
 #include "awk.h"
 #include "ytab.h"
 
-#define	HAT	(NCHARS+2)	/* matches ^ in regular expr */
-				/* NCHARS is 2**n */
 #define MAXLIN 22
 
 #define type(v)		(v)->nobj	/* badly overloaded here */


### PR DESCRIPTION
When matching a caret, the expression	`f->gototab[s][c] = f->curstat;` in
cgoto() will index the 2D-array gototab with [s][261]. However, gototab
is declared as being of size [NSTATES][NCHARS], so [32][259]. Therefore,
this assignment will write to the state for character 0x1.
I'm not sure how to create a regression test for this, but increasing the
array size to HAT+1 values fixes the error and the tests still pass.

I found this issue while running awk on a CHERI system with sub-object
protection enabled. On x86, this can be reproduced by compiling awk
with -fsanitize=undefined.