### PR TITLE
Avoid creating an out-of-bounds pointer in word()

### DIFF
--- a/lex.c
+++ b/lex.c
@@ -461,9 +461,8 @@ int word(char *w)
 	int c, n;
 
 	n = binsearch(w, keywords, sizeof(keywords)/sizeof(keywords[0]));
-/* BUG: this ought to be inside the if; in theory could fault (daniel barrett) */
-	kp = keywords + n;
 	if (n != -1) {	/* found in table */
+		kp = keywords + n;
 		yylval.i = kp->sub;
 		switch (kp->type) {	/* special handling */
 		case BLTIN:


### PR DESCRIPTION
As it is never dereferenced in the n == -1 case it shouldn't cause any
problems. However, UBSAN complains about this, so it is required to run
the tests when compiling with -fsanitize=undefined.

I was able to run `make test` with -fsanitize=undefined after applying this on top of #47.