### PR TITLE
Fix hwasan global overflow.

### DIFF
--- a/lex.c
+++ b/lex.c
@@ -30,7 +30,7 @@ THIS SOFTWARE.
 #include "ytab.h"
 
 extern YYSTYPE	yylval;
-extern int	infunc;
+extern bool	infunc;
 
 int	lineno	= 1;
 int	bracecnt = 0;

--- a/makefile
+++ b/makefile
@@ -22,6 +22,7 @@
 # THIS SOFTWARE.
 # ****************************************************************/
 
+CFLAGS = -fsanitize=address -O1 -g -fno-omit-frame-pointer -fno-optimize-sibling-calls
 CFLAGS = -g
 CFLAGS =
 CFLAGS = -O2


### PR DESCRIPTION
Crash found with https://source.android.com/devices/tech/debug/hwasan
but also detectable by regular ASan. Here's an ASan crash:

==215690==ERROR: AddressSanitizer: global-buffer-overflow on address
  0x55d90f8da140 at pc 0x55d90f8b7503 bp 0x7ffd3dae6100 sp 0x7ffd3dae60f8
  READ of size 4 at 0x55d90f8da140 thread T0
    #0 0x55d90f8b7502 in word /tmp/awk/lex.c:496
    #1 0x55d90f8b939f in yylex /tmp/awk/lex.c:191
    #2 0x55d90f894ab9 in yyparse /tmp/awk/awkgram.tab.c:2366
    #3 0x55d90f89edc2 in main /tmp/awk/main.c:216
    #4 0x7ff263a78bba in __libc_start_main ../csu/libc-start.c:308
    #5 0x55d90f8945a9 in _start (/tmp/awk/a.out+0x115a9)

0x55d90f8da141 is located 0 bytes to the right of global variable
'infunc' defined in 'awkgram.y:35:6' (0x55d90f8da140) of size 1

SUMMARY: AddressSanitizer: global-buffer-overflow /tmp/awk/lex.c:496 in word
Shadow bytes around the buggy address:
  0x0abba1f133d0: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0abba1f133e0: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0abba1f133f0: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0abba1f13400: f9 f9 f9 f9 00 00 00 00 00 00 00 00 00 00 00 00
  0x0abba1f13410: 00 f9 f9 f9 f9 f9 f9 f9 00 f9 f9 f9 f9 f9 f9 f9
=>0x0abba1f13420: 04 f9 f9 f9 f9 f9 f9 f9[01]f9 f9 f9 f9 f9 f9 f9
  0x0abba1f13430: 00 f9 f9 f9 f9 f9 f9 f9 00 f9 f9 f9 f9 f9 f9 f9
  0x0abba1f13440: 00 00 00 00 00 f9 f9 f9 f9 f9 f9 f9 04 f9 f9 f9
  0x0abba1f13450: f9 f9 f9 f9 00 f9 f9 f9 f9 f9 f9 f9 04 f9 f9 f9
  0x0abba1f13460: f9 f9 f9 f9 04 f9 f9 f9 f9 f9 f9 f9 04 f9 f9 f9
  0x0abba1f13470: f9 f9 f9 f9 00 f9 f9 f9 f9 f9 f9 f9 00 f9 f9 f9

And here's the stack trace from hwasan:

  Stack Trace:
  RELADDR           FUNCTION         FILE:LINE
  00000000000168d4  word             external/one-true-awk/lex.c:496:18
  000000000002d1ec  yyparse          y.tab.c:2460:16
  000000000001c82c  main             external/one-true-awk/main.c:179:2
  00000000000b41a0  __libc_init      bionic/libc/bionic/libc_init_dynamic.cpp:151:8

As it says, we're doing a 4-byte read from a 1-byte global.

`infunc` is declared as an int but defined as a bool.

Signed-off-by: Evgenii Stepanov <eugenis@google.com>