### PR TITLE
Replace __attribute__((__noreturn__)) with _Noreturn.

### DIFF
--- a/awk.h
+++ b/awk.h
@@ -25,6 +25,7 @@ THIS SOFTWARE.
 #include <assert.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <stdnoreturn.h>
 
 typedef double	Awkfloat;
 

--- a/main.c
+++ b/main.c
@@ -52,7 +52,7 @@ static size_t	curpfile;	/* current filename */
 
 bool	safe = false;	/* true => "safe" mode */
 
-static _Noreturn void fpecatch(int n
+static noreturn void fpecatch(int n
 #ifdef SA_SIGINFO
 	, siginfo_t *si, void *uc
 #endif

--- a/main.c
+++ b/main.c
@@ -52,7 +52,7 @@ static size_t	curpfile;	/* current filename */
 
 bool	safe = false;	/* true => "safe" mode */
 
-static __attribute__((__noreturn__)) void fpecatch(int n
+static _Noreturn void fpecatch(int n
 #ifdef SA_SIGINFO
 	, siginfo_t *si, void *uc
 #endif

--- a/proto.h
+++ b/proto.h
@@ -46,7 +46,7 @@ extern	void	freetr(Node *);
 extern	int	hexstr(const uschar **);
 extern	int	quoted(const uschar **);
 extern	char	*cclenter(const char *);
-extern	_Noreturn void	overflo(const char *);
+extern	noreturn void	overflo(const char *);
 extern	void	cfoll(fa *, Node *);
 extern	int	first(Node *);
 extern	void	follow(Node *);
@@ -137,7 +137,7 @@ extern	void	bracecheck(void);
 extern	void	bcheck2(int, int, int);
 extern	void	SYNTAX(const char *, ...)
     __attribute__((__format__(__printf__, 1, 2)));
-extern	_Noreturn void	FATAL(const char *, ...)
+extern	noreturn void	FATAL(const char *, ...)
     __attribute__((__format__(__printf__, 1, 2)));
 extern	void	WARNING(const char *, ...)
     __attribute__((__format__(__printf__, 1, 2)));

--- a/proto.h
+++ b/proto.h
@@ -46,7 +46,7 @@ extern	void	freetr(Node *);
 extern	int	hexstr(const uschar **);
 extern	int	quoted(const uschar **);
 extern	char	*cclenter(const char *);
-extern	void	overflo(const char *) __attribute__((__noreturn__));
+extern	_Noreturn void	overflo(const char *);
 extern	void	cfoll(fa *, Node *);
 extern	int	first(Node *);
 extern	void	follow(Node *);
@@ -137,8 +137,8 @@ extern	void	bracecheck(void);
 extern	void	bcheck2(int, int, int);
 extern	void	SYNTAX(const char *, ...)
     __attribute__((__format__(__printf__, 1, 2)));
-extern	void	FATAL(const char *, ...)
-    __attribute__((__format__(__printf__, 1, 2), __noreturn__));
+extern	_Noreturn void	FATAL(const char *, ...)
+    __attribute__((__format__(__printf__, 1, 2)));
 extern	void	WARNING(const char *, ...)
     __attribute__((__format__(__printf__, 1, 2)));
 extern	void	error(void);


### PR DESCRIPTION
`_Noreturn` is standard C and in my opinion, less ugly than `__attribute__((__noreturn__))`.

Should I use `noreturn` instead and `#include <stdnoreturn.h>`?