### PR TITLE
Fix concatenation regression

### DIFF
--- a/run.c
+++ b/run.c
@@ -1192,12 +1192,12 @@ Cell *cat(Node **a, int q)	/* a[0] cat a[1] */
 
 	x = execute(a[0]);
 	n1 = strlen(getsval(x));
+	adjbuf(&s, &ssz, n1, recsize, 0, "cat1");
+	memcpy(s, x->sval, n1);
 
 	y = execute(a[1]);
 	n2 = strlen(getsval(y));
-
-	adjbuf(&s, &ssz, n1 + n2 + 1, recsize, 0, "cat");
-	memcpy(s, x->sval, n1);
+	adjbuf(&s, &ssz, n1 + n2 + 1, recsize, 0, "cat2");
 	memcpy(s + n1, y->sval, n2);
 	s[n1 + n2] = '\0';
 


### PR DESCRIPTION
The optimization in commit 1d6ddfd9c0ed7119c0601474cded3a385068e886 reintroduced the regression that was fixed in commit e26237434fb769d9c1ea239101eb5b24be588eea.

The regression can be reproduced with the bugs-fixed/concat-assign-same.awk test added by the latter commit.