### PR TITLE
Fix regression with changed SUBSEP in subscript

### DIFF
--- a/run.c
+++ b/run.c
@@ -472,7 +472,7 @@ makearraystring(Node *p, const char *func)
 {
 	char *buf;
 	int bufsz = recsize;
-	size_t blen, seplen;
+	size_t blen;
 
 	if ((buf = malloc(bufsz)) == NULL) {
 		FATAL("%s: out of memory", func);
@@ -480,11 +480,11 @@ makearraystring(Node *p, const char *func)
 
 	blen = 0;
 	buf[blen] = '\0';
-	seplen = strlen(getsval(subseploc));
 
 	for (; p; p = p->nnext) {
 		Cell *x = execute(p);	/* expr */
 		char *s = getsval(x);
+		size_t seplen = strlen(getsval(subseploc));
 		size_t nsub = p->nnext ? seplen : 0;
 		size_t slen = strlen(s);
 		size_t tlen = blen + slen + nsub;


### PR DESCRIPTION
Commit 0d8778bbbb415810bfd126694a38b6bf4b71e79c reintroduced a regression that was fixed in commit 97a4b7ed215ae6446d13fe0eab15b5b3ae4da7da. The length of SUBSEP needs to be rechecked after calling execute(), in case SUBSEP itself has been changed.

The regression can be reproduced with the bugs-fixed/subsep-overflow.awk test added by the latter commit. The output is incorrect (e.g. on the first line 13503 should be 27001) and awk may segfault due to an out-of-bounds write.