### PR TITLE
Don't print extra newlines on error before awk starts parsing.

### DIFF
--- a/lib.c
+++ b/lib.c
@@ -669,12 +669,11 @@ void error()
 			fprintf(stderr, " source line number %d", curnode->lineno);
 		else if (lineno)
 			fprintf(stderr, " source line number %d", lineno);
+		if (compile_time == COMPILING && cursource() != NULL)
+			fprintf(stderr, " source file %s", cursource());
+		fprintf(stderr, "\n");
+		eprint();
 	}
-
-	if (compile_time == COMPILING && cursource() != NULL)
-		fprintf(stderr, " source file %s", cursource());
-	fprintf(stderr, "\n");
-	eprint();
 }
 
 void eprint(void)	/* try to print context around error */


### PR DESCRIPTION
If awk prints an error message while when compile_time is still set to ERROR_PRINTING, don't try to print the context since there is none.  This can happen due to a problem with, e.g., unknown command line options.