### PR TITLE
Include <strings.h> for strcasecmp

### DIFF
--- a/lib.c
+++ b/lib.c
@@ -25,6 +25,7 @@ THIS SOFTWARE.
 #define DEBUG
 #include <stdio.h>
 #include <string.h>
+#include <strings.h>
 #include <ctype.h>
 #include <errno.h>
 #include <stdlib.h>


### PR DESCRIPTION
Though some implementations include this header indirectly through
string.h by default, the POSIX header that declares strcasecmp is
strings.h[0].

[0] https://pubs.opengroup.org/onlinepubs/9699919799/functions/strcasecmp.html