### PR TITLE
Fix regular expression RS ^-anchoring

### DIFF
--- a/lib.c
+++ b/lib.c
@@ -176,6 +176,7 @@ int getrec(char **pbuf, int *pbufsize, bool isrecord)	/* get next input record *
 				infile = stdin;
 			else if ((infile = fopen(file, "r")) == NULL)
 				FATAL("can't open file %s", file);
+			innew = true;
 			setfval(fnrloc, 0.0);
 		}
 		c = readrec(&buf, &bufsize, infile, innew);

--- a/testdir/T.misc
+++ b/testdir/T.misc
@@ -195,6 +195,24 @@ aa1a2a
 EOF
 diff foo1 foo2 || echo 'BAD: T.misc ^regex reapplied fails'
 
+# ^-anchored RS matching should be active at the start of each input file
+tee foo1 foo2 >foo3 << \EOF
+aaa
+EOF
+$awk 1 RS='^a' foo1 foo2 foo3 >foo4
+cat << \EOF > foo5
+
+aa
+
+
+aa
+
+
+aa
+
+EOF
+diff foo4 foo5 || echo 'BAD: T.misc ^RS matches the start of every input file fails'
+
 # The following should not produce a warning about changing a constant
 # nor about a curdled tempcell list
 $awk 'function f(x) { x = 2 }


### PR DESCRIPTION
Hello.

When getrec opens a file, it isn't setting the flag, innew, which the main i/o loop uses to signify that it's reading the first record. readrec then misconfigures the regex machine in a way that precludes ^-anchored matching.

This commit fixes the problem by restoring a line which was accidentally overlooked while porting NetBSD's regex-RS functionality. It also adds a test to T.misc to detect the issue, should it ever recur.

I looked over the [original diff](https://github.com/NetBSD/src/commit/3b57b2e4d3f25a12d8fe7a9835d30724f1b27528) that I sent zoulasc in 2012, in case any other bits were missing, but everything else seems to be in place.

In the following examples, `nawk` is the current (at time of writing) tip of the onetrueawk/awk master branch (c0f4e97). `./a.out` is `nawk` with this pull request's commit applied.

If no files are named on the command line, initrec sets innew. This is the only context in which the broken implementation can match (it is also the only scenario which T.misc has been covering).
```
$ printf aaa | nawk 1 RS='^a'

aa
$ printf aaa | ./a.out 1 RS='^a'

aa
```

But if even a single file is named on the command line (even if it's stdin, which succeeded in the previous example), innew is not set and matching is impossible.
```
$ printf aaa | nawk 1 RS='^a' -
aaa
$ printf aaa | ./a.out 1 RS='^a' -

aa
```
If multiple files are named, innew is never set.
```
$ nawk 1 RS='^a' <(printf aaa) <(printf aaa) <(printf aaa)
aaa
aaa
aaa
$ ./a.out 1 RS='^a' <(printf aaa) <(printf aaa) <(printf aaa)

aa

aa

aa
```
I ran the test suite and didn't see any failures.

Thank you very much for your time.