### PR TITLE
awk: Make the historic -Ft to signify field separator as tab optional

### DIFF
--- a/main.c
+++ b/main.c
@@ -88,9 +88,11 @@ void segvcatch(int n)
 static const char *
 setfs(char *p)
 {
+#ifdef HISTORIC_FT_WART
 	/* wart: t=>\t */
 	if (p[0] == 't' && p[1] == '\0')
 		return "\t";
+#endif
 	else if (p[0] != '\0')
 		return p;
 	return NULL;


### PR DESCRIPTION
The historic behavior of awk has been to make -Ft mean -F\t. However,
that's a bit of a wart and antiquated. Make this behavior optional based
on a simple ifdef HISTORIC_FT_WART.