### PR TITLE
awk: Make -F '' and -v FS="" behave the same

### DIFF
--- a/main.c
+++ b/main.c
@@ -91,9 +91,7 @@ setfs(char *p)
 	/* wart: t=>\t */
 	if (p[0] == 't' && p[1] == '\0')
 		return "\t";
-	else if (p[0] != '\0')
-		return p;
-	return NULL;
+	return p;
 }
 
 static char *
@@ -169,8 +167,6 @@ int main(int argc, char *argv[])
  			break;
 		case 'F':	/* set field separator */
 			fs = setfs(getarg(&argc, &argv, "no field separator"));
-			if (fs == NULL)
-				WARNING("field separator FS is empty");
 			break;
 		case 'v':	/* -v a=1 to be done NOW.  one -v for each */
 			vn = getarg(&argc, &argv, "no variable name");


### PR DESCRIPTION
IEEE Std 1003.1-2008 mandates that -F str be treated the same as -v
FS=str. For a null string, this was not the case. Since awk(1) documents
that a null string for FS has a specific behavior, make -F '' behave
consistently with -v FS="".
