### PR TITLE
Don't decrease bracket count below 0 when lexing regexpr

### DIFF
--- a/lex.c
+++ b/lex.c
@@ -566,7 +566,9 @@ int regexpr(void)
 				unput(c);
 		} else if (c == ']') {
 			*bp++ = c;
-			brackets--;
+			if (brackets > 0) {
+				brackets--;
+			}
 		} else {
 			*bp++ = c;
 		}


### PR DESCRIPTION
Fix this error:
$ ./a.out '/][[]/'
./a.out: non-terminated regular expression ][[]/... at source line 1
 context is
         >>> /][[]/ <<<

Follow-up of #135