### PR TITLE
Eliminate file management memory leak

### DIFF
--- a/FIXES
+++ b/FIXES
@@ -25,6 +25,12 @@ THIS SOFTWARE.
 This file lists all bug fixes, changes, etc., made since the AWK book
 was sent to the printers in August, 1987.
 
+Mar 3, 2022:
+	Fixed file management memory leak that appears to have been
+	there since the files array was first initialized with stdin,
+	stdout, and stderr (circa 1992). Thanks to Miguel Pineiro Jr.
+	<mpj@pineiro.cc>.
+
 December 8, 2021:
 	The error handling in closefile and closeall was mangled. Long
 	standing warnings had been made fatal and some fatal errors went

--- a/main.c
+++ b/main.c
@@ -22,7 +22,7 @@ ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 ****************************************************************/
 
-const char	*version = "version 20211208";
+const char	*version = "version 20220303";
 
 #define DEBUG
 #include <stdio.h>

--- a/run.c
+++ b/run.c
@@ -1780,13 +1780,13 @@ static void stdinit(void)	/* in case stdin, etc., are not constants */
 	if (files == NULL)
 		FATAL("can't allocate file memory for %zu files", nfiles);
         files[0].fp = stdin;
-	files[0].fname = "/dev/stdin";
+	files[0].fname = tostring("/dev/stdin");
 	files[0].mode = LT;
         files[1].fp = stdout;
-	files[1].fname = "/dev/stdout";
+	files[1].fname = tostring("/dev/stdout");
 	files[1].mode = GT;
         files[2].fp = stderr;
-	files[2].fname = "/dev/stderr";
+	files[2].fname = tostring("/dev/stderr");
 	files[2].mode = GT;
 }
 
@@ -1890,8 +1890,7 @@ Cell *closefile(Node **a, int n)
 			stat = fclose(files[i].fp) == EOF;
 		if (stat)
 			WARNING("i/o error occurred closing %s", files[i].fname);
-		if (i > 2)	/* don't do /dev/std... */
-			xfree(files[i].fname);
+		xfree(files[i].fname);
 		files[i].fname = NULL;	/* watch out for ref thru this */
 		files[i].fp = NULL;
 		break;


### PR DESCRIPTION
stdinit initializes the first three slots of the files array
with statically allocated pathnames. closefile considers these
slots permanently statically allocated. openfile does not.

This discrepancy can leak memory: if a statically allocated slot
is vacated, openfile will put a malloc'd string where closefile
does not free.

To reconcile, either openfile must not reuse these slots or
stdinit and closefile must switch to dynamic allocation. I chose
the latter, because the result is a little simpler and less
interconnected than managing a partitioned array.

Here's a (contrived) demo with my system's output:

    $ cat leak.sh
    #!/bin/sh

    # Close stderr, vacating files[2]
    # Print the initial resident set size
    # For each record, open and close a file named "y"
    # Print rsz every 50,000 iterations
    # Exit after 250,000 iterations

    awk=${1:-nawk}
    yes | $awk '
            BEGIN {
		close("/dev/stderr")
		system(rsz = "ps -p $PPID -o rsz=")
	    }
	    { print > $0; close($0) }
	    NR % 50000 == 0 { system(rsz) }
	    NR == 250000    { exit }'

    # End of leak.sh

    $ paste <(./leak.sh ./master) <(./leak.sh ./a.out)
     2444	 2428
     4016	 2500
     5576	 2500
     7140	 2500
     8704	 2500
    10264	 2500

`make check` completed successfully.

The time you've taken to read this is appreciated,
Miguel