### PR TITLE
Avoid undefined behavior, passing memcpy() a NULL destination pointer.

### DIFF
--- a/run.c
+++ b/run.c
@@ -1195,21 +1195,29 @@ Cell *cat(Node **a, int q)	/* a[0] cat a[1] */
 
 	x = execute(a[0]);
 	n1 = strlen(getsval(x));
-	adjbuf(&s, &ssz, n1, recsize, 0, "cat1");
-	memcpy(s, x->sval, n1);
+	if (n1 != 0) {
+		adjbuf(&s, &ssz, n1 + 1, recsize, 0, "cat1");
+		memcpy(s, x->sval, n1);
+	}
+	tempfree(x);
 
 	y = execute(a[1]);
 	n2 = strlen(getsval(y));
-	adjbuf(&s, &ssz, n1 + n2 + 1, recsize, 0, "cat2");
-	memcpy(s + n1, y->sval, n2);
-	s[n1 + n2] = '\0';
-
-	tempfree(x);
+	if (n2 != 0) {
+		adjbuf(&s, &ssz, n1 + n2 + 1, recsize, 0, "cat2");
+		memcpy(s + n1, y->sval, n2);
+	}
 	tempfree(y);
 
 	z = gettemp();
-	z->sval = s;
-	z->tval = STR;
+	if (s != NULL) {
+		s[n1 + n2] = '\0';
+		z->sval = s;
+		z->tval = STR;
+	} else {
+		z->sval = EMPTY;
+		z->tval = STR|DONTFREE;
+	}
 
 	return(z);
 }


### PR DESCRIPTION
The C standard says that passing a NULL pointer results in undefined behavior, even if the byte count is 0.  This quiets the warning from UBSAN for, e.g. `'BEGIN { print foo[0] "" }'`
As pointed out by @mpinjr there is also a use-after-free where `y=execute(a[1])` could delete x so we need to free x before executing y.