### PR TITLE
Fix two use-after-free bugs when freeing a symbol table.

### DIFF
--- a/proto.h
+++ b/proto.h
@@ -98,6 +98,7 @@ extern	void	syminit(void);
 extern	void	arginit(int, char **);
 extern	void	envinit(char **);
 extern	Array	*makesymtab(int);
+extern	void	freesymtab2(Cell *, Cell *);
 extern	void	freesymtab(Cell *);
 extern	void	freeelem(Cell *, const char *);
 extern	Cell	*setsymtab(const char *, const char *, double, unsigned int, Array *);

--- a/run.c
+++ b/run.c
@@ -293,7 +293,7 @@ Cell *call(Node **a, int n)	/* function call.  very kludgy and fragile */
 		if (isarr(t)) {
 			if (t->csub == CCOPY) {
 				if (i >= ncall) {
-					freesymtab(t);
+					freesymtab2(t, y);
 					t->csub = CTEMP;
 					tempfree(t);
 				} else {
@@ -1279,7 +1279,7 @@ Cell *split(Node **a, int nnn)	/* split(a[0], a[1], a[2]); a[3] is type */
 		FATAL("illegal type of split");
 	sep = *fs;
 	ap = execute(a[1]);	/* array name */
-	freesymtab(ap);
+	freesymtab2(ap, y);
 	DPRINTF("split: s=|%s|, a=%s, sep=|%s|\n", s, NN(ap->nval), fs);
 	ap->tval &= ~STR;
 	ap->tval |= ARR;

--- a/tran.c
+++ b/tran.c
@@ -168,7 +168,7 @@ Array *makesymtab(int n)	/* make a new symbol table */
 	return(ap);
 }
 
-void freesymtab(Cell *ap)	/* free a symbol table */
+void freesymtab2(Cell *ap, Cell *y)	/* free a symbol table but preserve y */
 {
 	Cell *cp, *temp;
 	Array *tp;
@@ -181,11 +181,13 @@ void freesymtab(Cell *ap)	/* free a symbol table */
 		return;
 	for (i = 0; i < tp->size; i++) {
 		for (cp = tp->tab[i]; cp != NULL; cp = temp) {
-			xfree(cp->nval);
-			if (freeable(cp))
-				xfree(cp->sval);
 			temp = cp->cnext;	/* avoids freeing then using */
-			free(cp);
+			if (cp != y) {
+			    xfree(cp->nval);
+			    if (freeable(cp))
+				    xfree(cp->sval);
+			    free(cp);
+			}
 			tp->nelem--;
 		}
 		tp->tab[i] = NULL;
@@ -194,6 +196,11 @@ void freesymtab(Cell *ap)	/* free a symbol table */
 		WARNING("can't happen: inconsistent element count freeing %s", ap->nval);
 	free(tp->tab);
 	free(tp);
+}
+
+void freesymtab(Cell *ap)	/* free a symbol table */
+{
+    freesymtab2(ap, NULL);
 }
 
 void freeelem(Cell *ap, const char *s)	/* free elem s from ap (i.e., ap["s"] */


### PR DESCRIPTION
This introduces freesymtab2() which frees all elements of the symbol table except y.  The bugs can be reproduces with the following input under valgrind or address sanitizer:

    'BEGIN { unireghf() } function unireghf(hfeed) { hfeed[1] = 0 }'

    'BEGIN { a[1]="a b"; print split(a[1],a),a[1],a[2] }'