### PR TITLE
fix edge case where FS is changed on commandline

### DIFF
--- a/lib.c
+++ b/lib.c
@@ -105,6 +105,7 @@ void initgetrec(void)
 			return;
 		}
 		setclvar(p);	/* a commandline assignment before filename */
+		savefs(); /* in case FS is changed at commandline */
 		argno++;
 	}
 	infile = stdin;		/* no filenames, so use stdin */
@@ -167,6 +168,7 @@ int getrec(char **pbuf, int *pbufsize, bool isrecord)	/* get next input record *
 			}
 			if (isclvar(file)) {	/* a var=value arg */
 				setclvar(file);
+				savefs(); /* in case FS is changed at commandline */
 				argno++;
 				continue;
 			}


### PR DESCRIPTION
FS is not set when it's a value assigned on the command line:
```
$ cat > t1
1,2 3
4,5 6

shephard@Gordons-Air:~
$ awk '{printf "x"FS"x  "; print $1":"$2}' t1 FS="[ ,]" t1 t1
x x  1,2:3
x x  4,5:6
x[ ,]x  1,2:3
x[ ,]x  4:5
x[ ,]x  1:2
x[ ,]x  4:5
$ awk --version
awk version 20200816`
```