### PR TITLE
Fix regular expression clobbering in the lexer

### DIFF
--- a/awkgram.y
+++ b/awkgram.y
@@ -204,7 +204,7 @@ ppattern:
 		{ $$ = op2(BOR, notnull($1), notnull($3)); }
 	| ppattern and ppattern %prec AND
 		{ $$ = op2(AND, notnull($1), notnull($3)); }
-	| ppattern MATCHOP reg_expr	{ $$ = op3($2, NIL, $1, (Node*)makedfa($3, 0)); }
+	| ppattern MATCHOP reg_expr	{ $$ = op3($2, NIL, $1, (Node*)makedfa($3, 0)); free($3); }
 	| ppattern MATCHOP ppattern
 		{ if (constnode($3)) {
 			$$ = op3($2, NIL, $1, (Node*)makedfa(strnode($3), 0));
@@ -232,7 +232,7 @@ pattern:
 	| pattern LE pattern		{ $$ = op2($2, $1, $3); }
 	| pattern LT pattern		{ $$ = op2($2, $1, $3); }
 	| pattern NE pattern		{ $$ = op2($2, $1, $3); }
-	| pattern MATCHOP reg_expr	{ $$ = op3($2, NIL, $1, (Node*)makedfa($3, 0)); }
+	| pattern MATCHOP reg_expr	{ $$ = op3($2, NIL, $1, (Node*)makedfa($3, 0)); free($3); }
 	| pattern MATCHOP pattern
 		{ if (constnode($3)) {
 			$$ = op3($2, NIL, $1, (Node*)makedfa(strnode($3), 0));
@@ -282,7 +282,7 @@ rbrace:
 
 re:
 	   reg_expr
-		{ $$ = op3(MATCH, NIL, rectonode(), (Node*)makedfa($1, 0)); }
+		{ $$ = op3(MATCH, NIL, rectonode(), (Node*)makedfa($1, 0)); free($1); }
 	| NOT re	{ $$ = op1(NOT, notnull($2)); }
 	;
 
@@ -388,7 +388,7 @@ term:
 		  $$ = op2(INDEX, $3, (Node*)$5); }
 	| '(' pattern ')'		{ $$ = $2; }
 	| MATCHFCN '(' pattern comma reg_expr ')'
-		{ $$ = op3(MATCHFCN, NIL, $3, (Node*)makedfa($5, 1)); }
+		{ $$ = op3(MATCHFCN, NIL, $3, (Node*)makedfa($5, 1)); free($5); }
 	| MATCHFCN '(' pattern comma pattern ')'
 		{ if (constnode($5)) {
 			$$ = op3(MATCHFCN, NIL, $3, (Node*)makedfa(strnode($5), 1));
@@ -399,13 +399,13 @@ term:
 	| SPLIT '(' pattern comma varname comma pattern ')'     /* string */
 		{ $$ = op4(SPLIT, $3, makearr($5), $7, (Node*)STRING); }
 	| SPLIT '(' pattern comma varname comma reg_expr ')'    /* const /regexp/ */
-		{ $$ = op4(SPLIT, $3, makearr($5), (Node*)makedfa($7, 1), (Node *)REGEXPR); }
+		{ $$ = op4(SPLIT, $3, makearr($5), (Node*)makedfa($7, 1), (Node *)REGEXPR); free($7); }
 	| SPLIT '(' pattern comma varname ')'
 		{ $$ = op4(SPLIT, $3, makearr($5), NIL, (Node*)STRING); }  /* default */
 	| SPRINTF '(' patlist ')'	{ $$ = op1($1, $3); }
 	| string	 		{ $$ = celltonode($1, CCON); }
 	| subop '(' reg_expr comma pattern ')'
-		{ $$ = op4($1, NIL, (Node*)makedfa($3, 1), $5, rectonode()); }
+		{ $$ = op4($1, NIL, (Node*)makedfa($3, 1), $5, rectonode()); free($3); }
 	| subop '(' pattern comma pattern ')'
 		{ if (constnode($3)) {
 			$$ = op4($1, NIL, (Node*)makedfa(strnode($3), 1), $5, rectonode());
@@ -413,7 +413,7 @@ term:
 		  } else
 			$$ = op4($1, (Node *)1, $3, $5, rectonode()); }
 	| subop '(' reg_expr comma pattern comma var ')'
-		{ $$ = op4($1, NIL, (Node*)makedfa($3, 1), $5, $7); }
+		{ $$ = op4($1, NIL, (Node*)makedfa($3, 1), $5, $7); free($3); }
 	| subop '(' pattern comma pattern comma var ')'
 		{ if (constnode($3)) {
 			$$ = op4($1, NIL, (Node*)makedfa(strnode($3), 1), $5, $7);

--- a/lex.c
+++ b/lex.c
@@ -554,7 +554,7 @@ int regexpr(void)
 	*bp = 0;
 	if (c == 0)
 		SYNTAX("non-terminated regular expression %.10s...", buf);
-	yylval.s = buf;
+	yylval.s = tostring(buf);
 	unput('/');
 	RET(REGEXPR);
 }

--- a/testdir/T.misc
+++ b/testdir/T.misc
@@ -504,3 +504,9 @@ cmp -s foo1 foo2 || echo 'BAD: T.misc END must preserve $0'
 echo 'E 2' >foo1
 (trap '' PIPE; "$awk" 'BEGIN { print "hi"; }' 2>/dev/null; echo "E $?" >foo2) | :
 cmp -s foo1 foo2 || echo 'BAD: T.misc exit status on I/O error'
+
+# Check for clobbering of the lexer's regular expression buffer.
+# If the output is "a1" instead of "1b", /b/ clobbered /a/.
+echo 1b >foo1
+echo ab | $awk '{ sub(/a/, "b" ~ /b/); print }' >foo2
+cmp -s foo1 foo2 || echo 'BAD: T.misc lexer regex buffer clobbered'


### PR DESCRIPTION
It is a mistake for the lexer not to make a copy of regexp literals, because the parser may need to shift more than one of them onto its stack as it searches for a matching rule.

For the following demonstration, the correct output is "1b":

        $ echo ab | ./master 'sub(/a/, "b" ~ /b/)'
        a1

The debugging output confirms that /b/ clobbered /a/, incorrectly modifying sub's first argument:

        $ echo ab | ./master -d 'sub(/a/, "b" ~ /b/)' | grep reparse
        reparse <b>
        reparse <b>

One of those should have been "reparse \<a>".

I introduced this bug in a fix [1] for memory leaks discovered by Todd C. Miller [2]. This commit reverts my fix and applies a slightly modified version of Todd's recommendation (I omit the INDEX case because reg_expr is stored in a node).

[1] 577a67cc1f129e3ab240fcc47bf6f31cf6996b8e
[2] https://github.com/onetrueawk/awk/pull/156

Testing with `valgrind --leak-check=full $awk "$prog" </dev/null`, the leaks produce something like this:

==473055== 4 bytes in 1 blocks are definitely lost in loss record 36 of 128
==473055==    at 0x484586F: malloc (vg_replace_malloc.c:381)
==473055==    by 0x49E54FD: strdup (strdup.c:42)
==473055==    by 0x409288: tostring (tran.c:522)
==473055==    by 0x411DF5: regexpr (lex.c:557)
==473055==    by 0x402E99: yyparse (awkgram.tab.c:2251)
==473055==    by 0x402877: main (main.c:211)

Where $prog is any one of these one-liners:

'/abc/; /cde/'
'"abc" ~ /cde/; /fgh/'
'match(/abc/, /cde/)'
'split(/abc/, a, /cde/)'
'sub(/abc/, /cde/)'
'gsub(/abc/, /cde/)'
'sub(/abc/, /cde/, a)'
'gsub(/abc/, /cde/, a)'