### PR TITLE
nodealloc should take a size_t rather than an int

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -29,7 +29,7 @@ THIS SOFTWARE.
 #include "awk.h"
 #include "awkgram.tab.h"
 
-Node *nodealloc(int n)
+Node *nodealloc(size_t n)
 {
 	Node *x;
 

--- a/proto.h
+++ b/proto.h
@@ -68,7 +68,7 @@ extern	void	freefa(fa *);
 extern	int	pgetc(void);
 extern	char	*cursource(void);
 
-extern	Node	*nodealloc(int);
+extern	Node	*nodealloc(size_t);
 extern	Node	*exptostat(Node *);
 extern	Node	*node1(int, Node *);
 extern	Node	*node2(int, Node *, Node *);


### PR DESCRIPTION
There is no reason to cast to int anyway.