### PR TITLE
Use C99 syntax to declare variable length arrays at the end of a struct

### DIFF
--- a/awk.h
+++ b/awk.h
@@ -158,7 +158,7 @@ typedef struct Node {
 	struct	Node *nnext;
 	int	lineno;
 	int	nobj;
-	struct	Node *narg[1];	/* variable: actual size set by calling malloc */
+	struct	Node *narg[];	/* variable: actual size set by calling malloc */
 } Node;
 
 #define	NIL	((Node *) 0)
@@ -251,7 +251,7 @@ typedef struct fa {
 	int	initstat;
 	int	curstat;
 	int	accept;
-	struct	rrow re[1];	/* variable: actual size set by calling malloc */
+	struct	rrow re[];	/* variable: actual size set by calling malloc */
 } fa;
 
 

--- a/parse.c
+++ b/parse.c
@@ -33,7 +33,7 @@ Node *nodealloc(int n)
 {
 	Node *x;
 
-	x = (Node *) malloc(sizeof(*x) + (n-1) * sizeof(x));
+	x = (Node *) malloc(sizeof(*x) + n * sizeof(x));
 	if (x == NULL)
 		FATAL("out of space in nodealloc");
 	x->nnext = NULL;


### PR DESCRIPTION
This is standard in C99, and rather than confuse the compiler by having a size of [1], we can mark it so the compiler knows the array at the end is not a fixed size.