### PR TITLE
Use size_t to avoid potential undefined behavior caused by integer underflow

### DIFF
--- a/lex.c
+++ b/lex.c
@@ -603,8 +603,8 @@ void unput(int c)	/* put lexical character back on input */
 
 void unputstr(const char *s)	/* put a string back on input */
 {
-	int i;
+	size_t i;
 
-	for (i = strlen(s)-1; i >= 0; i--)
-		unput(s[i]);
+	for (i = strlen(s); i;)
+		unput(s[--i]);
 }


### PR DESCRIPTION
This was caught by the undefined behavior sanitizer.