### PR TITLE
Prevent double-free when y is in array t

### DIFF
--- a/proto.h
+++ b/proto.h
@@ -99,6 +99,7 @@ extern	void	arginit(int, char **);
 extern	void	envinit(char **);
 extern	Array	*makesymtab(int);
 extern	void	freesymtab(Cell *);
+extern	int	    freesymtabcheck(Cell *, Cell*);
 extern	void	freeelem(Cell *, const char *);
 extern	Cell	*setsymtab(const char *, const char *, double, unsigned int, Array *);
 extern	int	hash(const char *, int);

--- a/run.c
+++ b/run.c
@@ -293,14 +293,15 @@ Cell *call(Node **a, int n)	/* function call.  very kludgy and fragile */
 		if (isarr(t)) {
 			if (t->csub == CCOPY) {
 				if (i >= ncall) {
-					freesymtab(t);
+					if (freesymtabcheck(t, y)) {
+						freed = 1;
+					}
 					t->csub = CTEMP;
 					tempfree(t);
 				} else {
 					oargs[i]->tval = t->tval;
 					oargs[i]->tval &= ~(STR|NUM|DONTFREE);
 					oargs[i]->sval = t->sval;
-					tempfree(t);
 				}
 			}
 		} else if (t != y) {	/* kludge to prevent freeing twice */
@@ -313,9 +314,9 @@ Cell *call(Node **a, int n)	/* function call.  very kludgy and fragile */
 		}
 	}
 	tempfree(fcn);
-	if (isexit(y) || isnext(y))
-		return y;
 	if (freed == 0) {
+		if (isexit(y) || isnext(y))
+			return y;
 		tempfree(y);	/* don't free twice! */
 	}
 	z = frp->retval;			/* return value */

--- a/tran.c
+++ b/tran.c
@@ -196,6 +196,40 @@ void freesymtab(Cell *ap)	/* free a symbol table */
 	free(tp);
 }
 
+int freesymtabcheck(Cell *ap, Cell *needle)	/* free a symbol table, return 1 if needle was freed, 0 otherwise */
+{
+	Cell *cp, *temp;
+	Array *tp;
+	int i, retval = 0;
+
+	DPRINTF("insymtab %p: n=%s s=\"%s\" f=%g t=%o\n",
+		(void*)ap, ap->nval, ap->sval, ap->fval, ap->tval);
+
+	if (!isarr(ap))
+		return 0;
+	tp = (Array *) ap->sval;
+	if (tp == NULL)
+		return 0;
+	for (i = 0; i < tp->size; i++) {
+		for (cp = tp->tab[i]; cp != NULL; cp = temp) {
+			if (cp == needle)
+				retval = 1;
+			xfree(cp->nval);
+			if (freeable(cp))
+				xfree(cp->sval);
+			temp = cp->cnext;	/* avoids freeing then using */
+			free(cp);
+			tp->nelem--;
+		}
+		tp->tab[i] = NULL;
+	}
+	if (tp->nelem != 0)
+		WARNING("can't happen: inconsistent element count freeing %s", ap->nval);
+	free(tp->tab);
+	free(tp);
+	return retval;
+}
+
 void freeelem(Cell *ap, const char *s)	/* free elem s from ap (i.e., ap["s"] */
 {
 	Array *tp;


### PR DESCRIPTION
The code already accounts for when y is in frp->args, but not when it is in frp->args->csub. This PR changes that by adding a function that frees while checking to see if y was found in the array and subsequently freed.