### PR TITLE
Use upper scope "int i" scope instead of declaring another in the for loop.

### DIFF
--- a/run.c
+++ b/run.c
@@ -1349,7 +1349,7 @@ int format(char **pbuf, int *pbufsize, const char *s, Node *a)	/* printf-like co
 			int i;
 
 			if (ljust) { // print one char from t, then pad blanks
-				for (int i = 0; i < n; i++)
+				for (i = 0; i < n; i++)
 					*p++ = t[i];
 				for (i = 0; i < pad; i++) {
 					//printf(" ");
@@ -1360,7 +1360,7 @@ int format(char **pbuf, int *pbufsize, const char *s, Node *a)	/* printf-like co
 					//printf(" ");
 					*p++ = ' ';
 				}
-				for (int i = 0; i < n; i++)
+				for (i = 0; i < n; i++)
 					*p++ = t[i];
 			}
 			*p = 0;


### PR DESCRIPTION
There is a declaration of `int i` above the `if (ljust)` scope for use with a set of `for()` loops.  However, half the `for()` loops declare their own `int i` in the loop itself.  Both sets of `for()` loops should use the `int i` in the upper scope, or each `for()` loop should declare `int i` itself instead of shadowing the variable.