### PR TITLE
Fix a bad cast to char * that causes incorrect results on big endian.

### DIFF
--- a/b.c
+++ b/b.c
@@ -945,7 +945,7 @@ Node *primary(void)
 		rtok = relex();
 		if (rtok == ')') {	/* special pleading for () */
 			rtok = relex();
-			return unary(op2(CCL, NIL, (Node *) tostring("")));
+			return unary(op2(CCL, NIL, (Node *) cclenter("")));
 		}
 		np = regexp();
 		if (rtok == ')') {
@@ -968,7 +968,7 @@ Node *concat(Node *np)
 		return (concat(op2(CAT, np, primary())));
 	case EMPTYRE:
 		rtok = relex();
-		return (concat(op2(CAT, op2(CCL, NIL, (Node *) tostring("")),
+		return (concat(op2(CAT, op2(CCL, NIL, (Node *) cclenter("")),
 				primary())));
 	}
 	return (np);

--- a/b.c
+++ b/b.c
@@ -527,7 +527,7 @@ int first(Node *p)	/* collects initially active leaves of p into setvec */
 			setvec[lp] = 1;
 			setcnt++;
 		}
-		if (type(p) == CCL && (*(char *) right(p)) == '\0')
+		if (type(p) == CCL && (*(int *) right(p)) == 0)
 			return(0);		/* empty CCL */
 		return(1);
 	case PLUS:


### PR DESCRIPTION
Now that awk stores chars as int we need to cast the Node * to int *.

Fixes the following script on big endian CPUs.
```
BEGIN { work="K"; gsub("[x]", "J", work); print work; }
```

Before fix:
```
JKJ
```

After:
```
K
```

Thanks to George Koehler for simplifying the test case.