### PR TITLE
Correctly reset the goto table for a state.

### DIFF
--- a/b.c
+++ b/b.c
@@ -115,6 +115,7 @@ extern int u8_nextlen(const char *s);
 
 static int get_gototab(fa*, int, int);
 static int set_gototab(fa*, int, int, int);
+static void reset_gototab(fa*, int);
 extern int u8_rune(int *, const uschar *);
 
 static int *
@@ -268,8 +269,7 @@ int makeinit(fa *f, bool anchor)
 	}
 	if ((f->posns[2])[1] == f->accept)
 		f->out[2] = 1;
-	for (i = 0; i < NCHARS; i++)
-		set_gototab(f, 2, 0, 0); /* f->gototab[2][i] = 0; */
+	reset_gototab(f, 2);
 	f->curstat = cgoto(f, 2, HAT);
 	if (anchor) {
 		*f->posns[2] = k-1;	/* leave out position 0 */
@@ -605,6 +605,11 @@ static int get_gototab(fa *f, int state, int ch) /* hide gototab inplementation 
 			return f->gototab[state][i].state;
 	}
 	return 0;
+}
+
+static void reset_gototab(fa *f, int state) /* hide gototab inplementation */
+{
+	memset(f->gototab[state], 0, f->gototab_len * sizeof(**f->gototab));
 }
 
 static int set_gototab(fa *f, int state, int ch, int val) /* hide gototab inplementation */
@@ -1486,8 +1491,6 @@ int cgoto(fa *f, int s, int c)
 	/* add tmpset to current set of states */
 	++(f->curstat);
 	resize_state(f, f->curstat);
-	for (i = 0; i < NCHARS; i++)
-		set_gototab(f, f->curstat, 0, 0);
 	xfree(f->posns[f->curstat]);
 	p = intalloc(setcnt + 1, __func__);
 


### PR DESCRIPTION
We cannot use set_gototab() to reset all the entries for a state, it will leave existing entries as-is.  Add a new reset_gototab() function that zeroes the table entries for the specified state. There is no need to reset the goto table immediately after resize_state(), it is already initialized via calloc().