### PR TITLE
substr: fix buffer overflow with utf-8 strings

### DIFF
--- a/run.c
+++ b/run.c
@@ -985,7 +985,7 @@ Cell *substr(Node **a, int nnn)		/* substr(a[0], a[1], a[2]) */
 	if (a[2] != NULL)
 		z = execute(a[2]);
 	s = getsval(x);
-	k = strlen(s) + 1;
+	k = u8_strlen(s) + 1;
 	if (k <= 1) {
 		tempfree(x);
 		tempfree(y);


### PR DESCRIPTION
We need to use u8_strlen(), not strlen(), to compute the length. Otherwise, there may be an out of bounds write when writing the NUL terminator to set the length of the substring.