### PR TITLE
fnematch: fix out-of-bounds access on EOF

### DIFF
--- a/b.c
+++ b/b.c
@@ -850,13 +850,15 @@ bool fnematch(fa *pfa, FILE *f, char **pbuf, int *pbufsize, int quantum)
 		j = i++;
 		do {
 			r = getrune(f);
-			if ((++j + r.len) >= k) {
-				if (k >= bufsize)
-					if (!adjbuf((char **) &buf, &bufsize, bufsize+1, quantum, 0, "fnematch"))
-						FATAL("stream '%.30s...' too long", buf);
+			if (r.len == 0) {
+				r.len = 1;	// store NUL byte for EOF
+			}
+			j += r.len;
+			if (j >= bufsize) {
+				if (!adjbuf((char **) &buf, &bufsize, j+1, quantum, 0, "fnematch"))
+					FATAL("stream '%.30s...' too long", buf);
 			}
 			memcpy(buf + k, r.bytes, r.len);
-			j += r.len - 1;	// incremented next time around the loop
 			k += r.len;
 
 			if ((ns = get_gototab(pfa, s, r.rune)) != 0)


### PR DESCRIPTION
fnematch() expects to store a NUL byte when EOF is encountered. However, the rewrite broke this assumption because r.len from getrune() is zero on EOF.  This results in j becoming negative on EOF, causing an out-of-bounds access.  It is simplest to just force r.len to 1 on EOF to copy a single NUL byte--the rune is initialized to zero even for EOF.

This also fixes the call to adjbuf().  We cannot use 'k' to determine when we need to expand the buffer now that we are potentially reading more than a single byte at a time.