### PR TITLE
Fix exit status of system on MacOS.

### DIFF
--- a/bugs-fixed/REGRESS
+++ b/bugs-fixed/REGRESS
@@ -11,6 +11,7 @@ do
 	echo === $i
 	OUT=${i%.awk}.OUT
 	OK=${i%.awk}.ok
+	OK2=${i%.awk}.ok2
 	IN=${i%.awk}.in
 	input=
 	if [ -f $IN ]
@@ -22,7 +23,10 @@ do
 	if cmp -s $OK $OUT
 	then
 		rm -f $OUT
+	elif [ -f $OK2 ] && cmp -s $OK2 $OUT
+	then
+		rm -f $OUT
 	else
-		echo ++++ $i failed!
+		echo '++++ $i failed!'
 	fi
 done

--- a/bugs-fixed/system-status.ok2
+++ b/bugs-fixed/system-status.ok2
@@ -1,0 +1,3 @@
+normal status 42
+death by signal status 257
+death by signal with core dump status 262

--- a/run.c
+++ b/run.c
@@ -2108,7 +2108,7 @@ Cell *bltin(Node **a, int n)	/* builtin functions. a[0] is type, a[1] is arg lis
 		break;
 	case FSYSTEM:
 		fflush(stdout);		/* in case something is buffered already */
-		status = system(getsval(x));
+		estatus = status = system(getsval(x));
 		if (status != -1) {
 			if (WIFEXITED(status)) {
 				estatus = WEXITSTATUS(status);
@@ -2121,6 +2121,7 @@ Cell *bltin(Node **a, int n)	/* builtin functions. a[0] is type, a[1] is arg lis
 			} else	/* something else?!? */
 				estatus = 0;
 		}
+		/* else estatus was set to -1 */
 		u = estatus;
 		break;
 	case FRAND:

--- a/run.c
+++ b/run.c
@@ -2065,6 +2065,7 @@ Cell *bltin(Node **a, int n)	/* builtin functions. a[0] is type, a[1] is arg lis
 	Node *nextarg;
 	FILE *fp;
 	int status = 0;
+	int estatus = 0;
 
 	t = ptoi(a[0]);
 	x = execute(a[1]);
@@ -2108,19 +2109,19 @@ Cell *bltin(Node **a, int n)	/* builtin functions. a[0] is type, a[1] is arg lis
 	case FSYSTEM:
 		fflush(stdout);		/* in case something is buffered already */
 		status = system(getsval(x));
-		u = status;
 		if (status != -1) {
 			if (WIFEXITED(status)) {
-				u = WEXITSTATUS(status);
+				estatus = WEXITSTATUS(status);
 			} else if (WIFSIGNALED(status)) {
-				u = WTERMSIG(status) + 256;
+				estatus = WTERMSIG(status) + 256;
 #ifdef WCOREDUMP
 				if (WCOREDUMP(status))
-					u += 256;
+					estatus += 256;
 #endif
 			} else	/* something else?!? */
-				u = 0;
+				estatus = 0;
 		}
+		u = estatus;
 		break;
 	case FRAND:
 		/* random() returns numbers in [0..2^31-1]


### PR DESCRIPTION
For some bizarre reason, the result of `system()` on MacOS was coming back as floating point numbers. I changed things to use `int` and only set the floating point result at the end. MacOS also doesn't seem to set the WCOREDUMP bit, so I added an additional `.ok` file and updated the file `bugs-fixed/REGRESS`.  That file now also has a `^G` in it so that one only need look for the BEL character to find errors.