### PR TITLE
Restore ability to compile with g++.

### DIFF
--- a/FIXES
+++ b/FIXES
@@ -25,6 +25,10 @@ THIS SOFTWARE.
 This file lists all bug fixes, changes, etc., made since the 
 second edition of the AWK book was published in September 2023.
 
+Jan 22, 2024:
+	Restore the ability to compile with g++. Thanks to
+	Arnold Robbins.
+
 Dec 24, 2023:
 	matchop dereference after free problem fix when the first
 	argument is a function call. thanks to Oguz Ismail Uysal.

--- a/main.c
+++ b/main.c
@@ -22,7 +22,7 @@ ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 ****************************************************************/
 
-const char	*version = "version 20231228";
+const char	*version = "version 20240122";
 
 #define DEBUG
 #include <stdio.h>

--- a/run.c
+++ b/run.c
@@ -1300,7 +1300,8 @@ int format(char **pbuf, int *pbufsize, const char *s, Node *a)	/* printf-like co
 
 						if (bs == NULL)	{ // invalid character
 							// use unicode invalid character, 0xFFFD
-							bs = "\357\277\275";
+							static char invalid_char[] = "\357\277\275";
+							bs = invalid_char;
 							count = 3;
 						}
 						t = bs;
@@ -2448,7 +2449,7 @@ Cell *dosub(Node **a, int subop)        /* sub and gsub */
 	start = getsval(x);
 	while (pmatch(pfa, start)) {
 		if (buf == NULL) {
-			if ((pb = buf = malloc(bufsz)) == NULL)
+			if ((pb = buf = (char *) malloc(bufsz)) == NULL)
 				FATAL("out of memory in dosub");
 			tempstat = pfa->initstat;
 			pfa->initstat = 2;


### PR DESCRIPTION
C++ compilation was broken when we merged the UTF-8 support. This fixes things.

It's something of a band-aid. The mixing of signed and unsigned chars isn't all that healthy and ought to be really straightened out at some point.

In any case, it passes the test suite when compiled both with gcc and g++.  Enjoy.