### PR TITLE
Add RT to complement RS being a regex.

### DIFF
--- a/awk.h
+++ b/awk.h
@@ -69,6 +69,7 @@ extern size_t	awk_mb_cur_max;	/* max size of a multi-byte character */
 extern char	EMPTY[];	/* this avoid -Wwritable-strings issues */
 extern char	**FS;
 extern char	**RS;
+extern char	**RT;
 extern char	**ORS;
 extern char	**OFS;
 extern char	**OFMT;
@@ -121,6 +122,7 @@ extern Cell	*nfloc;		/* NF */
 extern Cell	*ofsloc;	/* OFS */
 extern Cell	*orsloc;	/* ORS */
 extern Cell	*rsloc;		/* RS */
+extern Cell	*rtloc;		/* RT */
 extern Cell	*rstartloc;	/* RSTART */
 extern Cell	*rlengthloc;	/* RLENGTH */
 extern Cell	*subseploc;	/* SUBSEP */

--- a/lib.c
+++ b/lib.c
@@ -225,17 +225,17 @@ extern int readcsvrec(char **pbuf, int *pbufsize, FILE *inf, bool newflag);
 
 int readrec(char **pbuf, int *pbufsize, FILE *inf, bool newflag)	/* read one record into buf */
 {
-	int sep, c, isrec; // POTENTIAL BUG? isrec is a macro in awk.h
+	int sep, c;
 	char *rr = *pbuf, *buf = *pbuf;
 	int bufsize = *pbufsize;
 	char *rs = getsval(rsloc);
+	const char *rt = NULL;
+	bool found = false;
 
 	if (CSV) {
 		c = readcsvrec(pbuf, pbufsize, inf, newflag);
-		isrec = (c == EOF && rr == buf) ? false : true;
+		rt = (c == EOF && rr == buf) ? NULL : rs;
 	} else if (*rs && rs[1]) {
-		bool found;
-
 		memset(buf, 0, bufsize);
 		fa *pfa = makedfa(rs, 1);
 		if (newflag)
@@ -246,10 +246,8 @@ int readrec(char **pbuf, int *pbufsize, FILE *inf, bool newflag)	/* read one rec
 			found = fnematch(pfa, inf, &buf, &bufsize, recsize);
 			pfa->initstat = tempstat;
 		}
-		if (found)
-			setptr(patbeg, '\0');
-		isrec = (found == 0 && *buf == '\0') ? false : true;
-
+		DPRINTF("readrec: found=%d, patbeg=%s\n", found, patbeg);
+		rt = found ? patbeg : NULL;
 	} else {
 		if ((sep = *rs) == 0) {
 			sep = '\n';
@@ -279,12 +277,21 @@ int readrec(char **pbuf, int *pbufsize, FILE *inf, bool newflag)	/* read one rec
 		if (!adjbuf(&buf, &bufsize, 1+rr-buf, recsize, &rr, "readrec 3"))
 			FATAL("input record `%.30s...' too long", buf);
 		*rr = 0;
-		isrec = (c == EOF && rr == buf) ? false : true;
+		rt = (c == EOF && rr == buf) ? NULL : rs;
 	}
 	*pbuf = buf;
 	*pbufsize = bufsize;
-	DPRINTF("readrec saw <%s>, returns %d\n", buf, isrec);
-	return isrec;
+
+	DPRINTF("readrec saw <%s>, returns %d\n", rt ? rt : "", !!rt);
+
+	if (rt) {
+		setsval(rtloc, rt);
+
+		if (found) /* remove pattern RS from record buffer */
+			setptr(patbeg, '\0');
+	}
+
+	return rt ? 1 : 0;
 }
 
 

--- a/tran.c
+++ b/tran.c
@@ -37,6 +37,7 @@ Array	*symtab;	/* main symbol table */
 
 char	**FS;		/* initial field sep */
 char	**RS;		/* initial record sep */
+char    **RT;           /* record terminator */
 char	**OFS;		/* output field sep */
 char	**ORS;		/* output record sep */
 char	**OFMT;		/* output format for numbers */
@@ -57,6 +58,7 @@ Cell	*fnrloc;	/* FNR */
 Cell	*ofsloc;	/* OFS */
 Cell	*orsloc;	/* ORS */
 Cell	*rsloc;		/* RS */
+Cell	*rtloc;		/* RT */
 Array	*ARGVtab;	/* symbol table containing ARGV[...] */
 Array	*ENVtab;	/* symbol table containing ENVIRON[...] */
 Cell	*rstartloc;	/* RSTART */
@@ -81,6 +83,8 @@ void syminit(void)	/* initialize symbol table with builtin vars */
 	FS = &fsloc->sval;
 	rsloc = setsymtab("RS", "\n", 0.0, STR|DONTFREE, symtab);
 	RS = &rsloc->sval;
+	rtloc = setsymtab("RT", "", 0.0, STR|DONTFREE, symtab);
+	RT = &rtloc->sval;
 	ofsloc = setsymtab("OFS", " ", 0.0, STR|DONTFREE, symtab);
 	OFS = &ofsloc->sval;
 	orsloc = setsymtab("ORS", "\n", 0.0, STR|DONTFREE, symtab);


### PR DESCRIPTION
Since `RS` can be defined as a regular expression, it makes it difficult to use `RS` both like this and also keep the input line verbatim because it effectively deletes the input line characters that match `RS`.

This pull requests adds the common extension of `RT` that is present in `busybox`, `gawk` and `goawk` that provides the matched value of `RS` for the current input record.