### PR TITLE
Store the Cell containing ARGV instead of the ARGV table itself.

### DIFF
--- a/lib.c
+++ b/lib.c
@@ -335,14 +335,16 @@ int readcsvrec(char **pbuf, int *pbufsize, FILE *inf, bool newflag) /* csv can h
 
 char *getargv(int n)	/* get ARGV[n] */
 {
+	Array *ap;
 	Cell *x;
 	char *s, temp[50];
-	extern Array *ARGVtab;
+	extern Cell *ARGVcell;
 
+	ap = (Array *)ARGVcell->sval;
 	snprintf(temp, sizeof(temp), "%d", n);
-	if (lookup(temp, ARGVtab) == NULL)
+	if (lookup(temp, ap) == NULL)
 		return NULL;
-	x = setsymtab(temp, "", 0.0, STR, ARGVtab);
+	x = setsymtab(temp, "", 0.0, STR, ap);
 	s = getsval(x);
 	DPRINTF("getargv(%d) returns |%s|\n", n, s);
 	return s;

--- a/testdir/T.argv
+++ b/testdir/T.argv
@@ -148,3 +148,25 @@ END {
                 printf("ARGV[%d] is %s\n", i, ARGV[i])
 }' >foo2
 diff foo1 foo2 || echo 'BAD: T.argv delete ARGV[2]'
+
+# deleting ARGV used to trigger a use-after-free crash when awk
+# iterates over it to read files.
+echo >foo1
+echo >foo2
+echo >foo3
+$awk 'BEGIN {
+	delete ARGV
+	ARGV[0] = "awk"
+	ARGV[1] = "/dev/null"
+	ARGC = 2
+} {
+	# this should not be executed
+	print "FILENAME: " FILENAME
+	fflush()
+}' foo1 foo2 foo3 >foo4
+
+awkstatus=$?
+diff /dev/null foo4
+if [ $? -ne 0 ] || [ $awkstatus -ne 0 ]; then
+	echo 'BAD: T.argv delete ARGV'
+fi


### PR DESCRIPTION
The underlying table (array) may change due to, for example, "delete ARGV".  However, the Cell that stores ARGV should not change.  Also remove the ENVtab global which is never used outside of envinit(). Fixes issue #229.