### PR TITLE
Remove g++ compilation warnings.

### DIFF
--- a/FIXES
+++ b/FIXES
@@ -25,15 +25,18 @@ THIS SOFTWARE.
 This file lists all bug fixes, changes, etc., made since the 
 second edition of the AWK book was published in September 2023.
 
+May 3, 2024:
+	Remove warnings when compiling with g++. Thanks to Arnold Robbins.
+
 Apr 22, 2024:
-	fixed regex engine gototab reallocation issue that was
-	introduced during the Nov 24 rewrite. Thanks to Arnold Robbins.
+	Fixed regex engine gototab reallocation issue that was
+	Introduced during the Nov 24 rewrite. Thanks to Arnold Robbins.
 	Fixed a scan bug in split in the case the separator is a single
 	character. thanks to Oguz Ismail for spotting the issue.
 
 Mar 10, 2024:
-	fixed use-after-free bug in fnematch due to adjbuf invalidating
-	the pointers to buf. thanks to github user caffe3 for spotting
+	Fixed use-after-free bug in fnematch due to adjbuf invalidating
+	the pointers to buf. Thanks to github user caffe3 for spotting
 	the issue and providing a fix, and to Miguel Pineiro Jr.
 	for the alternative fix.
 	MAX_UTF_BYTES in fnematch has been replaced with awk_mb_cur_max.

--- a/b.c
+++ b/b.c
@@ -645,7 +645,7 @@ static int set_gototab(fa *f, int state, int ch, int val) /* hide gototab implem
 		f->gototab[state].entries[0].state = val;
 		f->gototab[state].inuse++;
 		return val;
-	} else if (ch > f->gototab[state].entries[f->gototab[state].inuse-1].ch) {
+	} else if ((unsigned)ch > f->gototab[state].entries[f->gototab[state].inuse-1].ch) {
 		// not seen yet, insert and return
 		gtt *tab = & f->gototab[state];
 		if (tab->inuse + 1 >= tab->allocated)
@@ -869,7 +869,7 @@ bool fnematch(fa *pfa, FILE *f, char **pbuf, int *pbufsize, int quantum)
 		 * Call u8_rune with at least awk_mb_cur_max ahead in
 		 * the buffer until EOF interferes.
 		 */
-		if (k - j < awk_mb_cur_max) {
+		if (k - j < (int)awk_mb_cur_max) {
 			if (k + awk_mb_cur_max > buf + bufsize) {
 				char *obuf = buf;
 				adjbuf((char **) &buf, &bufsize,

--- a/main.c
+++ b/main.c
@@ -22,7 +22,7 @@ ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 ****************************************************************/
 
-const char	*version = "version 20240422";
+const char	*version = "version 20240503";
 
 #define DEBUG
 #include <stdio.h>
@@ -62,22 +62,42 @@ static noreturn void fpecatch(int n
 )
 {
 #ifdef SA_SIGINFO
-	static const char *emsg[] = {
-		[0] = "Unknown error",
-		[FPE_INTDIV] = "Integer divide by zero",
-		[FPE_INTOVF] = "Integer overflow",
-		[FPE_FLTDIV] = "Floating point divide by zero",
-		[FPE_FLTOVF] = "Floating point overflow",
-		[FPE_FLTUND] = "Floating point underflow",
-		[FPE_FLTRES] = "Floating point inexact result",
-		[FPE_FLTINV] = "Invalid Floating point operation",
-		[FPE_FLTSUB] = "Subscript out of range",
-	};
+	const char *mesg = NULL;
+
+	switch (si->si_code) {
+	case FPE_INTDIV:
+		mesg = "Integer divide by zero";
+		break;
+	case FPE_INTOVF:
+		mesg = "Integer overflow";
+		break;
+	case FPE_FLTDIV:
+		mesg = "Floating point divide by zero";
+		break;
+	case FPE_FLTOVF:
+		mesg = "Floating point overflow";
+		break;
+	case FPE_FLTUND:
+		mesg = "Floating point underflow";
+		break;
+	case FPE_FLTRES:
+		mesg = "Floating point inexact result";
+		break;
+	case FPE_FLTINV:
+		mesg = "Invalid Floating point operation";
+		break;
+	case FPE_FLTSUB:
+		mesg = "Subscript out of range";
+		break;
+	case 0:
+	default:
+		mesg = "Unknown error";
+		break;
+	}
 #endif
 	FATAL("floating point exception"
 #ifdef SA_SIGINFO
-		": %s", (size_t)si->si_code < sizeof(emsg) / sizeof(emsg[0]) &&
-		emsg[si->si_code] ? emsg[si->si_code] : emsg[0]
+		": %s", mesg
 #endif
 	    );
 }

--- a/makefile
+++ b/makefile
@@ -32,6 +32,7 @@ CFLAGS = -O2
 #CC = cc -O4 -Wall -pedantic -fno-strict-aliasing
 #CC = cc -fprofile-arcs -ftest-coverage # then gcov f1.c; cat f1.c.gcov
 HOSTCC = cc -g -Wall -pedantic -Wcast-qual
+# HOSTCC = g++ -g -Wall -pedantic -Wcast-qual
 CC = $(HOSTCC)  # change this is cross-compiling.
 
 # By fiat, to make our lives easier, yacc is now defined to be bison.

--- a/run.c
+++ b/run.c
@@ -724,7 +724,7 @@ int u8_byte2char(const char *s, int bytenum)
 	return charnum;
 }
 
-/* runetochar() adapted from rune.c in the Plan 9 distributione */
+/* runetochar() adapted from rune.c in the Plan 9 distribution */
 
 enum
 {
@@ -2061,7 +2061,7 @@ static char *nawk_tolower(const char *s)
 Cell *bltin(Node **a, int n)	/* builtin functions. a[0] is type, a[1] is arg list */
 {
 	Cell *x, *y;
-	Awkfloat u;
+	Awkfloat u = 0;
 	int t;
 	Awkfloat tmp;
 	char *buf;
@@ -2418,7 +2418,7 @@ Cell *dosub(Node **a, int subop)        /* sub and gsub */
 	const char *start;
 	const char *noempty = NULL;      /* empty match disallowed here */
 	size_t m = 0;                    /* match count */
-	size_t whichm;                   /* which match to select, 0 = global */
+	size_t whichm = 0;               /* which match to select, 0 = global */
 	int mtype;                       /* match type */
 
 	if (a[0] == NULL) {	/* 0 => a[1] is already-compiled regexpr */


### PR DESCRIPTION
The big change here is that C++ doesn't (yet, I guess) like C's indexed array initializers. I fixed some other warnings along the way.