### PR TITLE
spelling and prototype fixes

### DIFF
--- a/FIXES.1e
+++ b/FIXES.1e
@@ -224,7 +224,7 @@ January 9, 2020:
 	mere warnings. Thanks to Martijn Dekker <martijn@inlv.org>.
 
 January 5, 2020:
-	Fix a bug in the concatentation of two string constants into
+	Fix a bug in the concatenation of two string constants into
 	one done in the grammar.  Fixes GitHub issue #61.  Thanks
 	to GitHub user awkfan77 for pointing out the direction for
 	the fix.  New test T.concat added to the test suite.
@@ -866,7 +866,7 @@ Jan 13, 1999:
 	added a few (int) casts to silence useless compiler warnings.
 	e.g., errorflag= in run.c jump().
 
-	added proctab.c to the bundle outout; one less thing
+	added proctab.c to the bundle output; one less thing
 	to have to compile out of the box.
 
 	added calls to _popen and _pclose to the win95 stub for

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ this affects `length`, `substr`, `index`, `match`, `split`,
 points are not necessarily characters.
 
 UTF-8 sequences may appear in literal strings and regular expressions.
-Aribtrary characters may be included with `\u` followed by 1 to 8 hexadecimal digits.
+Arbitrary characters may be included with `\u` followed by 1 to 8 hexadecimal digits.
 
 ### Regular expressions ###
 

--- a/TODO
+++ b/TODO
@@ -14,6 +14,6 @@ and see exactly which tests fail:
    The beebe.tar file appears to be from sometime in the 1990s.
 
 3. Make the One True Awk valgrind clean. In particular add a
-   a test suite target that runs valgrind on all the tests and
+   test suite target that runs valgrind on all the tests and
    reports if there are any definite losses or any invalid reads
    or writes (similar to gawk's test of this nature).

--- a/awk.h
+++ b/awk.h
@@ -168,7 +168,6 @@ typedef struct Node {
 #define	NIL	((Node *) 0)
 
 extern Node	*winner;
-extern Node	*nullstat;
 extern Node	*nullnode;
 
 /* ctypes */

--- a/bugs-fixed/ofs-rebuild.awk
+++ b/bugs-fixed/ofs-rebuild.awk
@@ -10,7 +10,7 @@ BEGIN {
 	# Change OFS after (conceptually) rebuilding the record
 	OFS = "<>"
 
-	# Unmodifed nawk prints "a<>b<>3333<>d<>e<>f<>g" because
+	# Unmodified nawk prints "a<>b<>3333<>d<>e<>f<>g" because
 	# it delays rebuilding $0 until it's needed, and then it uses
 	# the current value of OFS. Oops.
 	print

--- a/lex.c
+++ b/lex.c
@@ -216,7 +216,7 @@ int yylex(void)
 				;
 			unput(c);
 			/*
-			 * Next line is a hack, itcompensates for
+			 * Next line is a hack, it compensates for
 			 * unput's treatment of \n.
 			 */
 			lineno++;

--- a/proto.h
+++ b/proto.h
@@ -34,9 +34,6 @@ extern	void	startreg(void);
 extern	int	input(void);
 extern	void	unput(int);
 extern	void	unputstr(const char *);
-extern	int	yylook(void);
-extern	int	yyback(int *, int);
-extern	int	yyinput(void);
 
 extern	fa	*makedfa(const char *, bool);
 extern	fa	*mkdfa(const char *, bool);
@@ -167,7 +164,6 @@ extern	Cell	*boolop(Node **, int);
 extern	Cell	*relop(Node **, int);
 extern	void	tfree(Cell *);
 extern	Cell	*gettemp(void);
-extern	Cell	*field(Node **, int);
 extern	Cell	*indirect(Node **, int);
 extern	Cell	*substr(Node **, int);
 extern	Cell	*sindex(Node **, int);

--- a/testdir/T.csconcat
+++ b/testdir/T.csconcat
@@ -1,4 +1,4 @@
-echo T.csconcat: test constant string concatentation
+echo T.csconcat: test constant string concatenation
 
 awk=${awk-../a.out}
 


### PR DESCRIPTION
Spelling fixes and remove unneeded prototype and extern.

Are yyback() yyinput() and yylook() prototypes needed?

popen() and pclose() prototypes duplicating system headers are for portability?