### PR TITLE
Fix the system-status test on OpenBSD

### DIFF
--- a/bugs-fixed/system-status.awk
+++ b/bugs-fixed/system-status.awk
@@ -9,7 +9,7 @@ BEGIN {
 	status = system("exit 42")
 	print "normal status", status
 
-	status = system("kill -HUP $$")
+	status = system("kill -KILL $$")
 	print "death by signal status", status
 
 	status = system("kill -ABRT $$")

--- a/bugs-fixed/system-status.ok
+++ b/bugs-fixed/system-status.ok
@@ -1,3 +1,3 @@
 normal status 42
-death by signal status 257
+death by signal status 265
 death by signal with core dump status 518

--- a/bugs-fixed/system-status.ok2
+++ b/bugs-fixed/system-status.ok2
@@ -1,3 +1,3 @@
 normal status 42
-death by signal status 257
+death by signal status 265
 death by signal with core dump status 262


### PR DESCRIPTION
/bin/sh on OpenBSD catches SIGHUP, which affects the return value of system() in the test. Use SIGKILL to ensure that the shell is terminated by a signal.

I've checked the new return value on FreeBSD, NetBSD, OpenBSD, macOS and Ubuntu.