### PR TITLE
Fixed clang warning

### DIFF
--- a/lib.c
+++ b/lib.c
@@ -755,7 +755,7 @@ void WARNING(const char *fmt, ...)
 	error();
 }
 
-void error()
+void error(void)
 {
 	extern Node *curnode;
 


### PR DESCRIPTION
```
lib.c:758:11: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
  758 | void error()
      |           ^
      |            void
1 warning generated.