### PR TITLE
makefile: use `?=` to respect environment variables

### DIFF
--- a/makefile
+++ b/makefile
@@ -43,7 +43,7 @@ endif
 # By fiat, to make our lives easier, yacc is now defined to be bison.
 # If you want something else, you're on your own.
 # YACC = yacc -d -b awkgram
-YACC ?= bison -d
+YACC = bison -d
 
 OFILES = b.o main.o parse.o proctab.o tran.o lib.o run.o lex.o
 SOURCE = awk.h awkgram.tab.c awkgram.tab.h proto.h awkgram.y lex.c b.c main.c \

--- a/makefile
+++ b/makefile
@@ -32,7 +32,14 @@ CFLAGS ?= -O2
 #CC = cc -fprofile-arcs -ftest-coverage # then gcov f1.c; cat f1.c.gcov
 HOSTCC ?= cc -g -Wall -pedantic -Wcast-qual
 # HOSTCC = g++ -g -Wall -pedantic -Wcast-qual
-CC ?= $(HOSTCC)  # change this is cross-compiling.
+CC ?= $(HOSTCC)  # change this if cross-compiling.
+
+# If CC is set but HOSTCC isn't, use CC for host compilation too
+ifdef CC
+ifndef HOSTCC_OVERRIDDEN
+HOSTCC = $(CC)
+endif
+endif
 # By fiat, to make our lives easier, yacc is now defined to be bison.
 # If you want something else, you're on your own.
 # YACC = yacc -d -b awkgram
@@ -49,6 +56,7 @@ SHIP = README LICENSE FIXES $(SOURCE) awkgram.tab.[ch].bak makefile  \
 a.out:	awkgram.tab.o $(OFILES)
 	$(CC) $(CFLAGS) awkgram.tab.o $(OFILES) $(ALLOC)  -lm
 
+awkgram.tab.o: awkgram.tab.c
 $(OFILES):	awk.h awkgram.tab.h proto.h
 
 awkgram.tab.c awkgram.tab.h:	awk.h proto.h awkgram.y

--- a/makefile
+++ b/makefile
@@ -22,32 +22,27 @@
 # THIS SOFTWARE.
 # ****************************************************************/
 
-CFLAGS = -fsanitize=address -O1 -g -fno-omit-frame-pointer -fno-optimize-sibling-calls
-CFLAGS = -g
-CFLAGS =
-CFLAGS = -O2
-
+CFLAGS ?= -fsanitize=address -O1 -g -fno-omit-frame-pointer -fno-optimize-sibling-calls
+CFLAGS ?= -g
+CFLAGS ?=
+CFLAGS ?= -O2
 # compiler options
 #CC = cc -Wall -g -Wwrite-strings
 #CC = cc -O4 -Wall -pedantic -fno-strict-aliasing
 #CC = cc -fprofile-arcs -ftest-coverage # then gcov f1.c; cat f1.c.gcov
-HOSTCC = cc -g -Wall -pedantic -Wcast-qual
+HOSTCC ?= cc -g -Wall -pedantic -Wcast-qual
 # HOSTCC = g++ -g -Wall -pedantic -Wcast-qual
-CC = $(HOSTCC)  # change this is cross-compiling.
-
+CC ?= $(HOSTCC)  # change this is cross-compiling.
 # By fiat, to make our lives easier, yacc is now defined to be bison.
 # If you want something else, you're on your own.
 # YACC = yacc -d -b awkgram
-YACC = bison -d
+YACC ?= bison -d
 
 OFILES = b.o main.o parse.o proctab.o tran.o lib.o run.o lex.o
-
 SOURCE = awk.h awkgram.tab.c awkgram.tab.h proto.h awkgram.y lex.c b.c main.c \
 	maketab.c parse.c lib.c run.c tran.c proctab.c
-
 LISTING = awk.h proto.h awkgram.y lex.c b.c main.c maketab.c parse.c \
 	lib.c run.c tran.c
-
 SHIP = README LICENSE FIXES $(SOURCE) awkgram.tab.[ch].bak makefile  \
 	 awk.1
 


### PR DESCRIPTION
This is needed to allow more configurable compilation, like static linking here: https://github.com/pkgforge/soarpkgs/blob/main/binaries/awk/static.official.source.yaml#L50