### PR TITLE
silence unused variable warning

### DIFF
--- a/run.c
+++ b/run.c
@@ -1978,7 +1978,6 @@ static char *nawk_convert(const char *s, int (*fun_c)(int),
 	size_t n       = 0;
 	wchar_t wc;
 	const size_t sz = awk_mb_cur_max;
-	int unused;
 
 	if (sz == 1) {
 		buf = tostring(s);
@@ -1992,14 +1991,7 @@ static char *nawk_convert(const char *s, int (*fun_c)(int),
 		buf = tostringN(s, strlen(s) * sz + 1);
 
 		(void) mbtowc(NULL, NULL, 0);	/* reset internal state */
-		/*
-		 * Reset internal state here too.
-		 * Assign result to avoid a compiler warning. (Casting to void
-		 * doesn't work.)
-		 * Increment said variable to avoid a different warning.
-		 */
-		unused = wctomb(NULL, L'\0');
-		unused++;
+		(void) wctomb(NULL, L'\0');	/* reset internal state */
 
 		ps   = s;
 		pbuf = buf;


### PR DESCRIPTION
gcc 16 got smarter and now complains about the (intentionally) unused variable:

run.c:1981:13: warning: variable 'unused' set but not used [-Wunused-but-set-variable=]

This variable appears to have been added solely to silence an unused return value warning. I'm not sure what combination of warning flags, compiler, and OS on which that was the case, but I believe a cast to void is the intended way to silence such warnings.

Trying to trick the compiler about a variable being used seems like a losing battle.