### PR TITLE
split: allocate space for NUL terminator in CSV mode

### DIFF
--- a/run.c
+++ b/run.c
@@ -1746,7 +1746,9 @@ Cell *split(Node **a, int nnn)	/* split(a[0], a[1], a[2]); a[3] is type */
 		pfa = NULL;
 
 	} else if (a[2] == NULL && CSV) {	/* CSV only if no explicit separator */
-		char *newt = (char *) malloc(strlen(s)); /* for building new string; reuse for each field */
+		char *newt = (char *) malloc(strlen(s) + 1); /* for building new string; reuse for each field */
+		if (newt == NULL)
+			FATAL("out of space in split");
 		for (;;) {
 			char *fr = newt;
 			n++;


### PR DESCRIPTION
If the string to be split doesn't contain a comma, the entire string will be written to the buffer, including the NUL terminator.  Because the size allocated does not take the NUL terminator into account, it will write the NUL one byte past the end of the buffer.

Found by Frank Denis using the Swival Security Scanner

https://github.com/Swival/security-audits/blob/015508ed21b8c5fabfd699ddbad6f82bf60780ed/openbsd-bin/audit-findings/071-csv-split-allocates-one-byte-too-few.md