### PR TITLE
Move u8_rune() into b.c and make it static inline.

### DIFF
--- a/b.c
+++ b/b.c
@@ -116,7 +116,42 @@ static int entry_cmp(const void *l, const void *r);
 static int get_gototab(fa*, int, int);
 static int set_gototab(fa*, int, int, int);
 static void clear_gototab(fa*, int);
-extern int u8_rune(int *, const char *);
+
+/* Convert (prefix of) utf8 string to utf-32 rune. */
+/* Sets *rune to the value, returns the length. */
+/* No error checking: watch out. */
+static inline int
+u8_rune(int *rune, const char *s)
+{
+	int n, ret;
+	unsigned char c;
+
+	c = s[0];
+	if (c < 128 || awk_mb_cur_max == 1) {
+		*rune = c;
+		return 1;
+	}
+
+	n = strlen(s);
+	if (n >= 2 && ((c>>5) & 0x7) == 0x6 && (s[1] & 0xC0) == 0x80) {
+		*rune = ((c & 0x1F) << 6) | (s[1] & 0x3F); /* 110xxxxx 10xxxxxx */
+		ret = 2;
+	} else if (n >= 3 && ((c>>4) & 0xF) == 0xE && (s[1] & 0xC0) == 0x80
+			  && (s[2] & 0xC0) == 0x80) {
+		*rune = ((c & 0xF) << 12) | ((s[1] & 0x3F) << 6) | (s[2] & 0x3F);
+			/* 1110xxxx 10xxxxxx 10xxxxxx */
+		ret = 3;
+	} else if (n >= 4 && ((c>>3) & 0x1F) == 0x1E && (s[1] & 0xC0) == 0x80
+			  && (s[2] & 0xC0) == 0x80 && (s[3] & 0xC0) == 0x80) {
+		*rune = ((c & 0x7) << 18) | ((s[1] & 0x3F) << 12) | ((s[2] & 0x3F) << 6) | (s[3] & 0x3F);
+			/* 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx */
+		ret = 4;
+	} else {
+		*rune = c;
+		ret = 1;
+	}
+	return ret; /* returns one byte if sequence doesn't look like utf */
+}
 
 static int *
 intalloc(size_t n, const char *f)

--- a/run.c
+++ b/run.c
@@ -621,41 +621,6 @@ int u8_isutf(const char *s)
 	return ret;
 }
 
-/* Convert (prefix of) utf8 string to utf-32 rune. */
-/* Sets *rune to the value, returns the length. */
-/* No error checking: watch out. */
-int u8_rune(int *rune, const char *s)
-{
-	int n, ret;
-	unsigned char c;
-
-	c = s[0];
-	if (c < 128 || awk_mb_cur_max == 1) {
-		*rune = c;
-		return 1;
-	}
-
-	n = strlen(s);
-	if (n >= 2 && ((c>>5) & 0x7) == 0x6 && (s[1] & 0xC0) == 0x80) {
-		*rune = ((c & 0x1F) << 6) | (s[1] & 0x3F); /* 110xxxxx 10xxxxxx */
-		ret = 2;
-	} else if (n >= 3 && ((c>>4) & 0xF) == 0xE && (s[1] & 0xC0) == 0x80
-			  && (s[2] & 0xC0) == 0x80) {
-		*rune = ((c & 0xF) << 12) | ((s[1] & 0x3F) << 6) | (s[2] & 0x3F);
-			/* 1110xxxx 10xxxxxx 10xxxxxx */
-		ret = 3;
-	} else if (n >= 4 && ((c>>3) & 0x1F) == 0x1E && (s[1] & 0xC0) == 0x80
-			  && (s[2] & 0xC0) == 0x80 && (s[3] & 0xC0) == 0x80) {
-		*rune = ((c & 0x7) << 18) | ((s[1] & 0x3F) << 12) | ((s[2] & 0x3F) << 6) | (s[3] & 0x3F);
-			/* 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx */
-		ret = 4;
-	} else {
-		*rune = c;
-		ret = 1;
-	}
-	return ret; /* returns one byte if sequence doesn't look like utf */
-}
-
 /* return length of next sequence: 1 for ascii or random, 2..4 for valid utf8 */
 int u8_nextlen(const char *s)
 {


### PR DESCRIPTION
Doing some profiling of a large script, I saw that `u8_rune()` could take 10% - 15% of the run time. I'm hoping that making it `static inline` in `b.c` will help some.  The test suite passes with this change.